### PR TITLE
Add quiz automation starter framework

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=your-key-here

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+.venv/
+quiz_log.db

--- a/README.md
+++ b/README.md
@@ -1,1 +1,42 @@
-# basic-ai-auto-assistant
+# Quiz Automation Starter
+
+This project provides a starting point for an application that watches a quiz,
+asks OpenAI's `o4-mini-high` model for answers, and automatically selects the
+correct option.
+
+## Setup
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+cp .env.example .env  # create and edit with your OpenAI key
+```
+
+## Usage
+
+```bash
+python run.py
+```
+
+Use the GUI to start, pause, or stop the automation. All events are logged to
+`quiz_log.db`.
+
+For headless scripting on Windows, the `automation.answer_question` helper can
+be wired into a loop that:
+
+1. Screenshots the quiz region.
+2. Pastes the OCR text into a ChatGPT browser tab.
+3. Waits up to 20 s for the model reply via OCR.
+4. Clicks the answer option that matches the returned letter.
+
+## Tests
+
+```bash
+pytest
+```
+
+## Optimisation Flags
+
+- `Settings.poll_interval` controls screenshot frequency.
+- `Watcher.preprocess` uses grayscale + adaptive thresholding for better OCR.

--- a/quiz_automation/automation.py
+++ b/quiz_automation/automation.py
@@ -1,0 +1,97 @@
+"""High-level workflow orchestrating quiz screenshot to ChatGPT answer selection."""
+from __future__ import annotations
+
+import time
+from typing import Tuple
+
+try:  # pragma: no cover - optional deps
+    import pyautogui
+    import pyperclip
+    import pytesseract
+except Exception:  # pragma: no cover
+    class pyautogui:  # type: ignore
+        @staticmethod
+        def screenshot(region=None):
+            return None
+        @staticmethod
+        def moveTo(x, y):
+            pass
+        @staticmethod
+        def hotkey(*args):
+            pass
+        @staticmethod
+        def click(x=None, y=None):
+            pass
+        @staticmethod
+        def press(key):
+            pass
+    class pyperclip:  # type: ignore
+        @staticmethod
+        def copy(text):
+            pass
+    class pytesseract:  # type: ignore
+        @staticmethod
+        def image_to_string(img):
+            return ""
+
+from typing import Any
+
+from .clicker import click_option
+
+
+def screenshot_region(region: Tuple[int, int, int, int]) -> Any:
+    """Capture *region* using pyautogui and return an image object."""
+    left, top, width, height = region
+    pyautogui.moveTo(left, top)  # move mouse to show activity
+    return pyautogui.screenshot(region=region)
+
+
+def send_question_to_chatgpt(question: str, input_pos: Tuple[int, int]) -> None:
+    """Paste *question* into ChatGPT window at *input_pos* and submit."""
+    pyperclip.copy(question)
+    pyautogui.hotkey("alt", "tab")  # assume toggles to ChatGPT
+    pyautogui.click(*input_pos)
+    pyautogui.hotkey("ctrl", "v")
+    pyautogui.press("enter")
+
+
+def read_chatgpt_response(region: Tuple[int, int, int, int], timeout: int = 20) -> str:
+    """Return OCR text of ChatGPT response area within *timeout* seconds."""
+    start = time.time()
+    while time.time() - start < timeout:
+        img = pyautogui.screenshot(region=region)
+        text = pytesseract.image_to_string(img)
+        if text.strip():
+            return text
+        time.sleep(1)
+    raise TimeoutError("No response from ChatGPT")
+
+
+def answer_question(
+    quiz_region: Tuple[int, int, int, int],
+    chat_input: Tuple[int, int],
+    chat_response_region: Tuple[int, int, int, int],
+    option_base: Tuple[int, int],
+    offset: int = 40,
+) -> str:
+    """Process one quiz question and click the predicted answer.
+
+    Returns the raw response text for logging or debugging.
+    """
+    # Screenshot quiz question and OCR
+    img = screenshot_region(quiz_region)
+    question = pytesseract.image_to_string(img)
+
+    # Send text to ChatGPT and wait for reply
+    send_question_to_chatgpt(question, chat_input)
+    response = read_chatgpt_response(chat_response_region)
+
+    # parse answer letter
+    letter = next((c for c in response.upper() if c in "ABCD"), None)
+    if letter is None:
+        raise ValueError(f"Could not parse answer from response: {response!r}")
+
+    idx = ord(letter) - ord("A")
+    pyautogui.hotkey("alt", "tab")  # return to quiz window
+    click_option(option_base, idx, offset)
+    return response

--- a/quiz_automation/chatgpt_client.py
+++ b/quiz_automation/chatgpt_client.py
@@ -1,0 +1,43 @@
+"""Minimal OpenAI client wrapper with retry logic."""
+from __future__ import annotations
+
+import json
+import time
+from typing import Optional
+
+try:  # pragma: no cover - optional dependency
+    from openai import OpenAI
+except Exception:  # pragma: no cover
+    OpenAI = None  # type: ignore
+
+from .config import settings
+
+
+class ChatGPTClient:
+    """Wrapper around the OpenAI SDK that returns a single-letter answer."""
+
+    def __init__(self, api_key: Optional[str] = None) -> None:
+        if OpenAI is None:  # pragma: no cover
+            raise RuntimeError("openai package not available")
+        self.client = OpenAI(api_key=api_key or settings.openai_api_key)
+
+    def _completion(self, prompt: str) -> str:
+        response = self.client.responses.create(
+            model="o4-mini-high",
+            input=[
+                {"role": "system", "content": "Reply with JSON {'answer':'A|B|C|D'}"},
+                {"role": "user", "content": prompt},
+            ],
+        )
+        return response.output_text
+
+    def ask(self, prompt: str, retries: int = 3) -> str:
+        """Return the model's single-letter answer with basic retries."""
+        for attempt in range(retries):
+            try:
+                raw = self._completion(prompt)
+                data = json.loads(raw)
+                return data["answer"]
+            except Exception:
+                time.sleep(2**attempt)
+        raise RuntimeError("Failed to get model response")

--- a/quiz_automation/clicker.py
+++ b/quiz_automation/clicker.py
@@ -1,0 +1,21 @@
+"""Mouse automation helpers using pyautogui."""
+from __future__ import annotations
+
+try:  # pragma: no cover - optional dependency
+    import pyautogui
+except Exception:  # pragma: no cover
+    class pyautogui:  # type: ignore
+        @staticmethod
+        def moveTo(x, y):
+            pass
+
+        @staticmethod
+        def click():
+            pass
+
+
+def click_option(base: tuple[int, int], index: int, offset: int = 40) -> None:
+    """Click the option at *index* relative to *base* coordinates."""
+    x, y = base
+    pyautogui.moveTo(x, y + index * offset)
+    pyautogui.click()

--- a/quiz_automation/config.py
+++ b/quiz_automation/config.py
@@ -1,0 +1,21 @@
+"""Configuration module for quiz automation.
+
+Loads environment variables using Pydantic settings. Use python-dotenv
+so local development can specify variables in a .env file.
+"""
+from __future__ import annotations
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Application settings loaded from environment or .env."""
+
+    openai_api_key: str = Field("", env="OPENAI_API_KEY")
+    poll_interval: float = 1.0
+
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
+
+
+settings = Settings()

--- a/quiz_automation/gui.py
+++ b/quiz_automation/gui.py
@@ -1,0 +1,64 @@
+"""PySide6 GUI exposing Start, Pause and Stop controls."""
+from __future__ import annotations
+
+from queue import Queue
+from typing import Optional
+
+from PySide6.QtWidgets import (
+    QApplication,
+    QLabel,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from .config import settings
+from .region_selector import select_region
+from .watcher import Watcher
+
+
+class QuizGUI:
+    """Tiny GUI to control the quiz automation workflow."""
+
+    def __init__(self, app: Optional[QApplication] = None) -> None:
+        self.app = app or QApplication.instance() or QApplication([])
+        self.window = QWidget()
+        self.window.setWindowTitle("Quiz Automation")
+        layout = QVBoxLayout(self.window)
+        self.status = QLabel("Idle")
+        self.start_btn = QPushButton("Start")
+        self.pause_btn = QPushButton("Pause")
+        self.stop_btn = QPushButton("Stop")
+        layout.addWidget(self.status)
+        layout.addWidget(self.start_btn)
+        layout.addWidget(self.pause_btn)
+        layout.addWidget(self.stop_btn)
+
+        self.start_btn.clicked.connect(self.start)
+        self.pause_btn.clicked.connect(self.pause)
+        self.stop_btn.clicked.connect(self.stop)
+
+        self.event_queue: Queue = Queue()
+        self.watcher: Optional[Watcher] = None
+
+    def start(self) -> None:
+        self.status.setText("Running")
+        region = select_region()
+        self.watcher = Watcher(region, self.event_queue, settings)
+        self.watcher.start()
+
+    def pause(self) -> None:
+        self.status.setText("Paused")
+        if self.watcher:
+            self.watcher.stop_flag.set()
+
+    def stop(self) -> None:
+        self.status.setText("Stopped")
+        if self.watcher:
+            self.watcher.stop_flag.set()
+            self.watcher.join()
+            self.watcher = None
+
+    def run(self) -> None:  # pragma: no cover - GUI loop
+        self.window.show()
+        self.app.exec()

--- a/quiz_automation/logger.py
+++ b/quiz_automation/logger.py
@@ -1,0 +1,32 @@
+"""SQLite logging for quiz automation events."""
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime
+
+
+class Logger:
+    """Simple SQLite logger that records events with timestamps."""
+
+    def __init__(self, path: str = "quiz_log.db") -> None:
+        self.conn = sqlite3.connect(path)
+        self.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS events (
+                ts TEXT,
+                action TEXT,
+                data TEXT
+            )
+            """
+        )
+
+    def log(self, action: str, data: str) -> None:
+        ts = datetime.utcnow().isoformat()
+        self.conn.execute(
+            "INSERT INTO events (ts, action, data) VALUES (?, ?, ?)",
+            (ts, action, data),
+        )
+        self.conn.commit()
+
+    def close(self) -> None:
+        self.conn.close()

--- a/quiz_automation/region_selector.py
+++ b/quiz_automation/region_selector.py
@@ -1,0 +1,17 @@
+"""Utilities for selecting and storing the quiz region on screen."""
+from __future__ import annotations
+
+from typing import Tuple
+
+# In a real implementation this would provide a GUI to let the user drag a
+# rectangle. For now we simply return a placeholder region.
+
+def select_region() -> Tuple[int, int, int, int]:
+    """Return a hard-coded region placeholder.
+
+    Returns
+    -------
+    tuple
+        (left, top, width, height) representing the selected region.
+    """
+    return (0, 0, 100, 100)

--- a/quiz_automation/utils.py
+++ b/quiz_automation/utils.py
@@ -1,0 +1,9 @@
+"""Miscellaneous helper functions."""
+from __future__ import annotations
+
+import hashlib
+
+
+def hash_text(text: str) -> str:
+    """Return a SHA256 hash for *text*."""
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()

--- a/quiz_automation/watcher.py
+++ b/quiz_automation/watcher.py
@@ -1,0 +1,97 @@
+"""Screen region watcher that captures screenshots and performs OCR."""
+from __future__ import annotations
+
+import time
+from threading import Event, Thread
+from typing import Tuple
+from queue import Queue
+
+try:  # pragma: no cover - optional heavy deps
+    import mss  # type: ignore
+except Exception:  # pragma: no cover
+    class mss:  # type: ignore
+        class mss:  # type: ignore
+            def __init__(self, *args, **kwargs):
+                pass
+            def grab(self, bbox):
+                return [[0]]
+try:  # pragma: no cover
+    import numpy as np  # type: ignore
+except Exception:  # pragma: no cover
+    class np:  # type: ignore
+        ndarray = object
+        @staticmethod
+        def array(obj):
+            return obj
+try:  # pragma: no cover
+    import pytesseract  # type: ignore
+except Exception:  # pragma: no cover
+    class pytesseract:  # type: ignore
+        @staticmethod
+        def image_to_string(img):
+            return ""
+try:  # pragma: no cover
+    import cv2  # type: ignore
+except Exception:  # pragma: no cover
+    class cv2:  # type: ignore
+        COLOR_BGRA2GRAY = 0
+        ADAPTIVE_THRESH_GAUSSIAN_C = 0
+        THRESH_BINARY = 0
+        @staticmethod
+        def cvtColor(img, code):
+            return img
+        @staticmethod
+        def adaptiveThreshold(src, maxValue, adaptiveMethod, thresholdType, blockSize, C):
+            return src
+
+from .config import Settings
+from .utils import hash_text
+
+
+class Watcher(Thread):
+    """Background thread that polls a region for new questions."""
+
+    def __init__(self, region: Tuple[int, int, int, int], event_queue: Queue, cfg: Settings):
+        super().__init__(daemon=True)
+        self.region = region
+        self.event_queue = event_queue
+        self.cfg = cfg
+        self.stop_flag = Event()
+        self.last_hash = ""
+        self.sct = mss.mss()
+
+    def capture(self):
+        """Capture the configured region as a numpy array."""
+        left, top, width, height = self.region
+        bbox = {"left": left, "top": top, "width": width, "height": height}
+        img = np.array(self.sct.grab(bbox))
+        return img
+
+    @staticmethod
+    def preprocess(img):
+        """Apply grayscale and adaptive threshold for better OCR."""
+        gray = cv2.cvtColor(img, cv2.COLOR_BGRA2GRAY)
+        thresh = cv2.adaptiveThreshold(
+            gray, 255, cv2.ADAPTIVE_THRESH_GAUSSIAN_C, cv2.THRESH_BINARY, 31, 2
+        )
+        return thresh
+
+    def ocr(self, img) -> str:
+        processed = self.preprocess(img)
+        return pytesseract.image_to_string(processed)
+
+    def is_new_question(self, text: str) -> bool:
+        """Return True if the text is different from the last seen question."""
+        h = hash_text(text)
+        if h != self.last_hash and text.strip():
+            self.last_hash = h
+            return True
+        return False
+
+    def run(self) -> None:  # pragma: no cover - loop control tested separately
+        while not self.stop_flag.is_set():
+            img = self.capture()
+            text = self.ocr(img)
+            if self.is_new_question(text):
+                self.event_queue.put(("question", text, img))
+            time.sleep(self.cfg.poll_interval)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+mss==9.0.1
+pytesseract==0.3.10
+opencv-python==4.9.0.80
+pyautogui==0.9.54
+PySide6==6.6.2
+python-dotenv==1.0.1
+pydantic==2.6.4
+pydantic-settings==2.0.3
+openai==1.10.0
+pytest==8.2.1
+pytest-qt==4.2.0
+ruff==0.1.8
+pyperclip==1.9.0

--- a/run.py
+++ b/run.py
@@ -1,0 +1,13 @@
+"""Entry point for running the quiz automation GUI."""
+from __future__ import annotations
+
+from quiz_automation.gui import QuizGUI
+
+
+def main() -> None:
+    gui = QuizGUI()
+    gui.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path for imports
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))

--- a/tests/test_automation.py
+++ b/tests/test_automation.py
@@ -1,0 +1,45 @@
+from quiz_automation import automation
+
+
+def test_answer_question(monkeypatch):
+    # Mock pyautogui functions
+    actions = []
+    def fake_hotkey(*args):
+        actions.append(("hotkey", args))
+    def fake_click(x=None, y=None):
+        actions.append(("click", x, y))
+    def fake_press(key):
+        actions.append(("press", key))
+    def fake_screenshot(region=None):
+        # Return a unique object each call
+        return object()
+    monkeypatch.setattr(automation.pyautogui, "hotkey", fake_hotkey)
+    monkeypatch.setattr(automation.pyautogui, "click", fake_click)
+    monkeypatch.setattr(automation.pyautogui, "press", fake_press)
+    monkeypatch.setattr(automation.pyautogui, "screenshot", fake_screenshot)
+    monkeypatch.setattr(automation.pyautogui, "moveTo", lambda x, y: None)
+
+    # Mock clipboard
+    copied = {}
+    def fake_copy(text):
+        copied["text"] = text
+    monkeypatch.setattr(automation.pyperclip, "copy", fake_copy)
+
+    # Mock OCR
+    calls = []
+    def fake_ocr(img):
+        calls.append(img)
+        return "B" if len(calls) > 1 else "question"
+    monkeypatch.setattr(automation.pytesseract, "image_to_string", fake_ocr)
+
+    # Track click_option
+    clicked = {}
+    def fake_click_option(base, idx, offset=40):
+        clicked["idx"] = idx
+    monkeypatch.setattr(automation, "click_option", fake_click_option)
+
+    resp = automation.answer_question((0,0,10,10), (1,1), (2,2,10,10), (3,3))
+    assert resp == "B"
+    assert clicked["idx"] == 1
+    assert copied["text"] == "question"
+    assert ("hotkey", ("alt", "tab")) in actions

--- a/tests/test_chatgpt_client.py
+++ b/tests/test_chatgpt_client.py
@@ -1,0 +1,40 @@
+from quiz_automation import chatgpt_client
+from quiz_automation.chatgpt_client import ChatGPTClient
+
+
+class DummyOpenAI:
+    def __init__(self, api_key=None):
+        pass
+
+    class responses:  # type: ignore
+        @staticmethod
+        def create(**kwargs):
+            class R:
+                output_text = ""
+            return R()
+
+
+def test_chatgpt_client_parses_json_response(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    monkeypatch.setattr(chatgpt_client, "OpenAI", DummyOpenAI)
+    client = ChatGPTClient()
+    monkeypatch.setattr(client, "_completion", lambda prompt: '{"answer":"C"}')
+    assert client.ask("Q?") == "C"
+
+
+def test_chatgpt_client_retries_on_error(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    monkeypatch.setattr(chatgpt_client, "OpenAI", DummyOpenAI)
+    client = ChatGPTClient()
+    calls = {"n": 0}
+
+    def fake(prompt: str) -> str:
+        calls["n"] += 1
+        if calls["n"] < 2:
+            raise ValueError("boom")
+        return '{"answer":"A"}'
+
+    monkeypatch.setattr(client, "_completion", fake)
+    monkeypatch.setattr("quiz_automation.chatgpt_client.time.sleep", lambda s: None)
+    assert client.ask("Q?") == "A"
+    assert calls["n"] == 2

--- a/tests/test_clicker.py
+++ b/tests/test_clicker.py
@@ -1,0 +1,13 @@
+from quiz_automation.clicker import click_option
+
+
+def test_click_option(monkeypatch):
+    moves = []
+    clicks = []
+    monkeypatch.setattr(
+        "quiz_automation.clicker.pyautogui.moveTo", lambda x, y: moves.append((x, y))
+    )
+    monkeypatch.setattr("quiz_automation.clicker.pyautogui.click", lambda: clicks.append(True))
+    click_option((10, 10), 1, offset=5)
+    assert moves == [(10, 15)]
+    assert clicks == [True]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,13 @@
+from quiz_automation.config import Settings
+
+
+def test_config_loads_env(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    cfg = Settings()
+    assert cfg.openai_api_key == "test"
+
+
+def test_config_default_poll_interval(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    cfg = Settings()
+    assert cfg.poll_interval == 1.0

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,12 @@
+import sqlite3
+
+from quiz_automation.logger import Logger
+
+
+def test_logger_writes_entry(tmp_path):
+    db = tmp_path / "test.db"
+    logger = Logger(str(db))
+    logger.log("action", "data")
+    rows = list(sqlite3.connect(db).execute("SELECT action, data FROM events"))
+    assert rows[0] == ("action", "data")
+    logger.close()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,9 @@
+from quiz_automation.utils import hash_text
+
+
+def test_hash_text_consistent():
+    assert hash_text("hello") == hash_text("hello")
+
+
+def test_hash_text_different():
+    assert hash_text("hello") != hash_text("world")

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -1,0 +1,38 @@
+from queue import Queue
+
+from quiz_automation.config import Settings
+from quiz_automation.watcher import Watcher
+
+
+class DummyMSS:
+    def grab(self, bbox):
+        return [[0]]  # minimal placeholder
+
+
+def test_watcher_is_new_question(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    monkeypatch.setattr("quiz_automation.watcher.mss.mss", lambda: DummyMSS())
+    cfg = Settings()
+    watcher = Watcher((0, 0, 1, 1), Queue(), cfg)
+    assert watcher.is_new_question("Q1") is True
+    assert watcher.is_new_question("Q1") is False
+
+
+def test_watcher_emits_event(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    monkeypatch.setattr("quiz_automation.watcher.mss.mss", lambda: DummyMSS())
+    cfg = Settings()
+    q: Queue = Queue()
+    watcher = Watcher((0, 0, 1, 1), q, cfg)
+    monkeypatch.setattr(watcher, "capture", lambda: "img")
+    monkeypatch.setattr(watcher, "ocr", lambda img: "text")
+    monkeypatch.setattr(watcher, "is_new_question", lambda text: True)
+
+    def fake_sleep(_):
+        watcher.stop_flag.set()
+
+    monkeypatch.setattr("quiz_automation.watcher.time.sleep", fake_sleep)
+    watcher.run()
+    assert not q.empty()
+    event = q.get()
+    assert event[0] == "question"


### PR DESCRIPTION
## Summary
- scaffold quiz automation package with GUI, watcher, OpenAI client, and utilities
- document setup and provide pinned requirements
- include missing `pydantic-settings` dependency
- add window automation workflow sending questions to ChatGPT and clicking returned answer

## Testing
- `python -m ruff check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893e431cbd08328aaa2a6ce2b4528f4