### PR TITLE
Implement quiz runner thread with GUI controls

### DIFF
--- a/quiz_automation/config.py
+++ b/quiz_automation/config.py
@@ -12,6 +12,7 @@ class Settings(BaseSettings):
     """Application settings loaded from environment or .env."""
 
     poll_interval: float = 1.0
+    openai_api_key: str | None = None
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 

--- a/quiz_automation/gui.py
+++ b/quiz_automation/gui.py
@@ -15,6 +15,7 @@ from PySide6.QtWidgets import (
 from .config import settings
 from .region_selector import select_region
 from .watcher import Watcher
+from .runner import QuizRunner
 
 
 class QuizGUI:
@@ -40,17 +41,24 @@ class QuizGUI:
 
         self.event_queue: Queue = Queue()
         self.watcher: Optional[Watcher] = None
+        self.runner: Optional[QuizRunner] = None
 
     def start(self) -> None:
         self.status.setText("Running")
         region = select_region()
         self.watcher = Watcher(region, self.event_queue, settings)
         self.watcher.start()
+        # Placeholder coordinates for demo purposes; in a real application these
+        # would be gathered via the watcher or additional selectors.
+        self.runner = QuizRunner(region, (0, 0), region, ["A"], (0, 0))
+        self.runner.start()
 
     def pause(self) -> None:
         self.status.setText("Paused")
         if self.watcher:
             self.watcher.stop_flag.set()
+        if self.runner:
+            self.runner.stop_flag.set()
 
     def stop(self) -> None:
         self.status.setText("Stopped")
@@ -58,6 +66,10 @@ class QuizGUI:
             self.watcher.stop_flag.set()
             self.watcher.join()
             self.watcher = None
+        if self.runner:
+            self.runner.stop_flag.set()
+            self.runner.join()
+            self.runner = None
 
     def run(self) -> None:  # pragma: no cover - GUI loop
         self.window.show()

--- a/quiz_automation/region_selector.py
+++ b/quiz_automation/region_selector.py
@@ -1,0 +1,54 @@
+"""Utility for interactively selecting and persisting screen regions."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Tuple, Optional
+
+try:  # pragma: no cover - optional dependency
+    import pyautogui
+except Exception:  # pragma: no cover
+    class pyautogui:  # type: ignore
+        @staticmethod
+        def position():
+            return (0, 0)
+
+
+class RegionSelector:
+    """Persist coordinates of named screen regions to a JSON file."""
+
+    def __init__(self, path: Path | str = "coords.json") -> None:
+        self.path = Path(path)
+        if self.path.exists():
+            self.coords: Dict[str, Tuple[int, int, int, int]] = {
+                k: tuple(v) for k, v in json.loads(self.path.read_text()).items()
+            }
+        else:
+            self.coords = {}
+
+    def save(self) -> None:
+        data = {k: list(v) for k, v in self.coords.items()}
+        self.path.write_text(json.dumps(data))
+
+    def load(self, name: str) -> Optional[Tuple[int, int, int, int]]:
+        return self.coords.get(name)
+
+    def select(self, name: str) -> Tuple[int, int, int, int]:
+        """Interactively record a region and store it under *name*."""
+        input("Move to top-left and press Enter")
+        x1, y1 = pyautogui.position()
+        input("Move to bottom-right and press Enter")
+        x2, y2 = pyautogui.position()
+        region = (x1, y1, x2 - x1, y2 - y1)
+        self.coords[name] = region
+        self.save()
+        return region
+
+
+def select_region(name: str = "quiz", path: Path | str = "coords.json") -> Tuple[int, int, int, int]:
+    """Load a stored region by *name* or interactively create it."""
+    selector = RegionSelector(path)
+    region = selector.load(name)
+    if region is None:
+        region = selector.select(name)
+    return region

--- a/quiz_automation/runner.py
+++ b/quiz_automation/runner.py
@@ -1,0 +1,37 @@
+"""Thread that repeatedly answers quiz questions via the ChatGPT UI."""
+from __future__ import annotations
+
+import threading
+from typing import Sequence, Tuple
+
+from .automation import answer_question_via_chatgpt
+
+
+class QuizRunner(threading.Thread):
+    """Call :func:`answer_question_via_chatgpt` in a loop until stopped."""
+
+    def __init__(
+        self,
+        quiz_region: Tuple[int, int, int, int],
+        chatgpt_box: Tuple[int, int],
+        response_region: Tuple[int, int, int, int],
+        options: Sequence[str],
+        option_base: Tuple[int, int],
+    ) -> None:
+        super().__init__(daemon=True)
+        self.quiz_region = quiz_region
+        self.chatgpt_box = chatgpt_box
+        self.response_region = response_region
+        self.options = options
+        self.option_base = option_base
+        self.stop_flag = threading.Event()
+
+    def run(self) -> None:  # pragma: no cover - behaviour tested indirectly
+        while not self.stop_flag.is_set():
+            answer_question_via_chatgpt(
+                self.quiz_region,
+                self.chatgpt_box,
+                self.response_region,
+                self.options,
+                self.option_base,
+            )

--- a/quiz_automation/watcher.py
+++ b/quiz_automation/watcher.py
@@ -1,1 +1,30 @@
-=
+"""Simple background watcher thread used by the GUI.
+
+The real project might monitor the screen for changes and push events into an
+output queue.  For the purposes of the tests we only need a lightweight thread
+that respects a stop flag and periodically posts a tick event.
+"""
+from __future__ import annotations
+
+import threading
+import time
+from queue import Queue
+from typing import Tuple
+
+from .config import Settings
+
+
+class Watcher(threading.Thread):
+    """Periodically place a tick event into a queue until stopped."""
+
+    def __init__(self, region: Tuple[int, int, int, int], queue: Queue, settings: Settings) -> None:
+        super().__init__(daemon=True)
+        self.region = region
+        self.queue = queue
+        self.settings = settings
+        self.stop_flag = threading.Event()
+
+    def run(self) -> None:  # pragma: no cover - trivial loop
+        while not self.stop_flag.is_set():
+            self.queue.put({"region": self.region})
+            time.sleep(self.settings.poll_interval)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,47 @@
+from quiz_automation.runner import QuizRunner
+from quiz_automation import automation
+
+
+def test_runner_triggers_full_flow(monkeypatch):
+    calls = {"screenshot": 0, "paste": 0, "read": 0, "click": 0}
+
+    def fake_screenshot(region=None):
+        calls["screenshot"] += 1
+        return "img"
+
+    monkeypatch.setattr(automation.pyautogui, "screenshot", fake_screenshot)
+    monkeypatch.setattr(automation.pyautogui, "moveTo", lambda x, y: None)
+    monkeypatch.setattr(automation.pytesseract, "image_to_string", lambda img: "A")
+
+    def fake_send(img, box):
+        calls["paste"] += 1
+
+    monkeypatch.setattr(automation, "send_to_chatgpt", fake_send)
+
+    def fake_read(region, timeout=20.0):
+        calls["read"] += 1
+        return "Answer A"
+
+    monkeypatch.setattr(automation, "read_chatgpt_response", fake_read)
+
+    def fake_click(base, idx, offset=40):
+        calls["click"] += 1
+
+    monkeypatch.setattr(automation, "click_option", fake_click)
+
+    runner = QuizRunner((0, 0, 10, 10), (0, 0), (0, 0, 10, 10), ["A", "B"], (0, 0))
+
+    orig = automation.answer_question_via_chatgpt
+
+    def wrapped(*args, **kwargs):
+        result = orig(*args, **kwargs)
+        runner.stop_flag.set()
+        return result
+
+    monkeypatch.setattr(automation, "answer_question_via_chatgpt", wrapped)
+    monkeypatch.setattr("quiz_automation.runner.answer_question_via_chatgpt", wrapped)
+
+    runner.start()
+    runner.join(timeout=1)
+
+    assert calls == {"screenshot": 1, "paste": 1, "read": 1, "click": 1}


### PR DESCRIPTION
## Summary
- add a `QuizRunner` thread to repeatedly invoke ChatGPT answers until signaled to stop
- extend automation helpers for ChatGPT interaction and answer clicking
- wire GUI controls to manage both watcher and runner threads
- provide region persistence utilities and comprehensive runner test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894364d948883289ee21d95f799553c