### PR TITLE
Handle ChatGPT timeouts and add logging

### DIFF
--- a/quiz_automation/config.py
+++ b/quiz_automation/config.py
@@ -12,6 +12,7 @@ class Settings(BaseSettings):
     """Application settings loaded from environment or .env."""
 
     poll_interval: float = 1.0
+    openai_api_key: str | None = None
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 

--- a/quiz_automation/region_selector.py
+++ b/quiz_automation/region_selector.py
@@ -1,0 +1,48 @@
+"""Utility for interactively selecting screen regions."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Tuple
+
+try:  # pragma: no cover - optional dependency
+    import pyautogui
+except Exception:  # pragma: no cover
+    class pyautogui:  # type: ignore
+        @staticmethod
+        def position() -> Tuple[int, int]:
+            return (0, 0)
+
+
+class RegionSelector:
+    """Persist and recall user-selected screen regions."""
+
+    def __init__(self, path: Path | str) -> None:
+        self.path = Path(path)
+        if self.path.exists():
+            loaded = json.loads(self.path.read_text())
+            self.regions: Dict[str, Tuple[int, int, int, int]] = {
+                k: tuple(v) for k, v in loaded.items()
+            }
+        else:
+            self.regions = {}
+
+    def _save(self) -> None:
+        self.path.write_text(json.dumps(self.regions))
+
+    def select(self, name: str) -> Tuple[int, int, int, int]:
+        """Interactively select a region and store it under *name*."""
+        input("Move to top-left and press Enter")
+        x1, y1 = pyautogui.position()
+        input("Move to bottom-right and press Enter")
+        x2, y2 = pyautogui.position()
+        region = (x1, y1, x2 - x1, y2 - y1)
+        self.regions[name] = region
+        self._save()
+        return region
+
+    def load(self, name: str) -> Tuple[int, int, int, int] | None:
+        """Load a previously saved region."""
+        region = self.regions.get(name)
+        return tuple(region) if region is not None else None
+

--- a/tests/test_chatgpt_flow.py
+++ b/tests/test_chatgpt_flow.py
@@ -1,0 +1,77 @@
+import sqlite3
+
+from quiz_automation import automation
+from quiz_automation.logger import Logger
+
+
+def test_read_chatgpt_response_logs_timeout(monkeypatch, tmp_path):
+    """read_chatgpt_response refreshes once and logs timeouts."""
+
+    # Always return blank text so OCR never succeeds
+    monkeypatch.setattr(automation.pyautogui, "screenshot", lambda region=None: "img")
+    monkeypatch.setattr(automation.pytesseract, "image_to_string", lambda img: "")
+
+    # Capture refresh hotkey usage
+    hotkeys: list[tuple[str, ...]] = []
+    monkeypatch.setattr(
+        automation.pyautogui, "hotkey", lambda *keys: hotkeys.append(keys)
+    )
+
+    # Speed up polling
+    monkeypatch.setattr(automation.time, "sleep", lambda _t: None)
+
+    db = tmp_path / "log.db"
+    logger = Logger(str(db))
+
+    text = automation.read_chatgpt_response(
+        (0, 0, 1, 1), timeout=0, poll=0, logger=logger
+    )
+    assert text == ""
+    assert hotkeys == [("ctrl", "r")]
+
+    rows = list(sqlite3.connect(db).execute("SELECT action, data FROM events"))
+    assert rows[0][0] == "timeout"
+    logger.close()
+
+
+def test_answer_question_via_chatgpt_skips_on_timeout(monkeypatch, tmp_path):
+    """Timeouts do not crash the loop and produce no clicks."""
+
+    logger = Logger(str(tmp_path / "log.db"))
+
+    monkeypatch.setattr(automation, "screenshot_region", lambda region: "img")
+    monkeypatch.setattr(automation, "send_to_chatgpt", lambda img, box: None)
+
+    # Make read_chatgpt_response always timeout and log
+    monkeypatch.setattr(
+        automation,
+        "read_chatgpt_response",
+        lambda region, timeout=0, poll=0, logger=None: (
+            logger.log("timeout", "{}".format(region)) if logger else "",
+            ""
+        )[1],
+    )
+
+    monkeypatch.setattr(automation, "_extract_letter", lambda r: r, raising=False)
+
+    clicked: list[int] = []
+    monkeypatch.setattr(
+        automation,
+        "click_option",
+        lambda base, idx, offset=40: clicked.append(idx),
+    )
+
+    # Simulate loop with two iterations to ensure no crash
+    for _ in range(2):
+        letter = automation.answer_question_via_chatgpt(
+            (0, 0, 1, 1),
+            (0, 0),
+            (0, 0, 1, 1),
+            ["A", "B"],
+            (0, 0),
+            logger=logger,
+        )
+        assert letter == ""
+
+    assert clicked == []
+    logger.close()


### PR DESCRIPTION
## Summary
- retry ChatGPT OCR after refresh and log a structured timeout event
- skip unanswered ChatGPT questions instead of crashing and record progress
- add region selection persistence and support `OPENAI_API_KEY`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894364f19a883288732edab1ed1abc6