### PR TITLE
Add threaded capture pipeline with stats tracking and GUI display

### DIFF
--- a/quiz_automation/automation.py
+++ b/quiz_automation/automation.py
@@ -1,1 +1,88 @@
-=
+from __future__ import annotations
+
+"""High level helpers to interact with the ChatGPT quiz interface."""
+
+import time
+from typing import Any, Sequence, Tuple
+
+try:  # pragma: no cover - optional heavy dependency
+    import pyautogui  # type: ignore
+    import pytesseract  # type: ignore
+except Exception:  # pragma: no cover
+    from types import SimpleNamespace
+
+    pyautogui = SimpleNamespace(
+        screenshot=lambda *a, **k: None,
+        moveTo=lambda *a, **k: None,
+        hotkey=lambda *a, **k: None,
+        click=lambda *a, **k: None,
+    )  # type: ignore[attr-defined]
+    pytesseract = SimpleNamespace(image_to_string=lambda *a, **k: "")  # type: ignore[attr-defined]
+
+from .utils import copy_image_to_clipboard, validate_region
+from .stats import Stats
+
+
+def send_to_chatgpt(img: Any, box: Tuple[int, int]) -> None:
+    """Paste *img* into the ChatGPT input box located at *box*."""
+
+    if not hasattr(pyautogui, "moveTo"):  # pragma: no cover - guard for missing dependency
+        raise RuntimeError("pyautogui not available")
+    copy_image_to_clipboard(img)
+    pyautogui.moveTo(*box)
+    # ``hotkey`` is easier for tests to monkeypatch than writing characters
+    pyautogui.hotkey("ctrl", "v")
+
+
+def read_chatgpt_response(response_region: Tuple[int, int, int, int], timeout: float = 20.0) -> str:
+    """Return OCR'd text from *response_region* until non-empty or timeout."""
+
+    if not hasattr(pyautogui, "screenshot") or not hasattr(pytesseract, "image_to_string"):  # pragma: no cover
+        raise RuntimeError("required libraries not available")
+    validate_region(response_region)
+    start = time.time()
+    while time.time() - start < timeout:
+        img = pyautogui.screenshot(response_region)
+        text = pytesseract.image_to_string(img).strip()
+        if text:
+            return text
+        time.sleep(0.5)
+    raise TimeoutError("No response detected")
+
+
+def click_option(base: Tuple[int, int], index: int, offset: int = 40) -> None:
+    """Click the answer option at *index* using *base* as the first option."""
+
+    if not hasattr(pyautogui, "moveTo"):  # pragma: no cover
+        raise RuntimeError("pyautogui not available")
+    x, y = base
+    pyautogui.moveTo(x, y + index * offset)
+    pyautogui.click()
+
+
+def answer_question_via_chatgpt(
+    quiz_image: Any,
+    chatgpt_box: Tuple[int, int],
+    response_region: Tuple[int, int, int, int],
+    options: Sequence[str],
+    option_base: Tuple[int, int],
+    stats: Stats | None = None,
+) -> str:
+    """Send *quiz_image* to ChatGPT and click the model's chosen answer."""
+
+    start = time.time()
+    send_to_chatgpt(quiz_image, chatgpt_box)
+    response = read_chatgpt_response(response_region)
+    letter = response.strip().split()[-1].upper() if response else "A"
+    try:
+        idx = options.index(letter)
+    except ValueError:
+        idx = max(0, ord(letter) - ord("A"))
+    click_option(option_base, idx)
+
+    if stats is not None:
+        duration = time.time() - start
+        tokens = len(response.split()) if response else 0
+        stats.record(duration, tokens)
+
+    return letter

--- a/quiz_automation/config.py
+++ b/quiz_automation/config.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+"""Configuration handling for the quiz automation package."""
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Read configuration from environment variables."""
+
+    openai_api_key: str | None = None
+    poll_interval: float = 1.0
+
+    model_config = SettingsConfigDict(env_prefix="", extra="ignore")
+
+
+# A module-level settings instance convenient for components that do not need
+# their own configuration object.
+settings = Settings()

--- a/quiz_automation/gui.py
+++ b/quiz_automation/gui.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+"""Simple PySide6 based GUI for displaying live quiz metrics."""
+
+from typing import Optional
+
+try:  # pragma: no cover - optional graphical dependency
+    from PySide6.QtWidgets import QApplication, QLabel, QVBoxLayout, QWidget
+except Exception:  # pragma: no cover - fall back when Qt is unavailable
+    QApplication = QLabel = QVBoxLayout = QWidget = None  # type: ignore
+
+from .stats import Stats
+
+
+class QuizGUI:
+    """Display :class:`Stats` in a lightweight window.
+
+    The widget is intentionally tiny so that unit tests can instantiate it
+    without starting a full GUI environment.  When PySide6 is not available, the
+    class still stores the last rendered text for inspection by tests.
+    """
+
+    def __init__(self) -> None:
+        self._app: Optional[QApplication]
+        self._label: Optional[QLabel]
+        self._last_text: str = ""
+
+        if QApplication is None:  # pragma: no cover - headless fallback
+            self._app = None
+            self._label = None
+            return
+
+        self._app = QApplication.instance() or QApplication([])
+        self._window = QWidget()
+        layout = QVBoxLayout(self._window)
+        self._label = QLabel("Ready")
+        layout.addWidget(self._label)
+        self._window.setWindowTitle("Quiz Stats")
+        self._window.show()
+
+    def update(self, stats: Stats) -> None:
+        """Refresh the GUI with the latest *stats*."""
+
+        text = (
+            f"Questions: {stats.questions_answered} | "
+            f"Avg Time: {stats.average_time:.2f}s | "
+            f"Avg Tokens: {stats.average_tokens:.1f} | "
+            f"Errors: {stats.errors}"
+        )
+        self._last_text = text
+
+        if self._label is not None:  # pragma: no branch - only if GUI is active
+            self._label.setText(text)
+            # ``processEvents`` keeps the UI responsive during tests without a
+            # full event loop running.
+            assert self._app is not None  # for type checkers
+            self._app.processEvents()
+
+    @property
+    def last_text(self) -> str:
+        """Return the most recently rendered text."""
+
+        return self._last_text

--- a/quiz_automation/runner.py
+++ b/quiz_automation/runner.py
@@ -1,14 +1,19 @@
 """Thread that repeatedly answers quiz questions via the ChatGPT UI."""
 from __future__ import annotations
 
+import queue
 import threading
+import time
 from typing import Sequence, Tuple
 
+from . import automation
 from .automation import answer_question_via_chatgpt
+from .stats import Stats
+from .gui import QuizGUI
 
 
 class QuizRunner(threading.Thread):
-    """Call :func:`answer_question_via_chatgpt` in a loop until stopped."""
+    """Run a capture/worker pipeline until :attr:`stop_flag` is set."""
 
     def __init__(
         self,
@@ -17,6 +22,9 @@ class QuizRunner(threading.Thread):
         response_region: Tuple[int, int, int, int],
         options: Sequence[str],
         option_base: Tuple[int, int],
+        *,
+        stats: Stats | None = None,
+        gui: QuizGUI | None = None,
     ) -> None:
         super().__init__(daemon=True)
         self.quiz_region = quiz_region
@@ -25,13 +33,46 @@ class QuizRunner(threading.Thread):
         self.options = options
         self.option_base = option_base
         self.stop_flag = threading.Event()
+        self.stats = stats or Stats()
+        self.gui = gui
 
-    def run(self) -> None:  # pragma: no cover - behaviour tested indirectly
-        while not self.stop_flag.is_set():
-            answer_question_via_chatgpt(
-                self.quiz_region,
-                self.chatgpt_box,
-                self.response_region,
-                self.options,
-                self.option_base,
-            )
+    # The behaviour of this method is tested indirectly via unit tests that
+    # patch :func:`answer_question_via_chatgpt`, so it is excluded from coverage
+    def run(self) -> None:  # pragma: no cover
+        q: queue.Queue = queue.Queue(maxsize=1)
+
+        def capture() -> None:
+            while not self.stop_flag.is_set():
+                if q.empty():
+                    img = automation.pyautogui.screenshot(self.quiz_region)
+                    q.put(img)
+                else:
+                    time.sleep(0.05)
+
+        def worker() -> None:
+            while not self.stop_flag.is_set() or not q.empty():
+                try:
+                    img = q.get(timeout=0.1)
+                except queue.Empty:
+                    continue
+                try:
+                    answer_question_via_chatgpt(
+                        img,
+                        self.chatgpt_box,
+                        self.response_region,
+                        self.options,
+                        self.option_base,
+                        stats=self.stats,
+                    )
+                except Exception:
+                    self.stats.record_error()
+                finally:
+                    if self.gui is not None:
+                        self.gui.update(self.stats)
+
+        t_capture = threading.Thread(target=capture, daemon=True)
+        t_worker = threading.Thread(target=worker, daemon=True)
+        t_capture.start()
+        t_worker.start()
+        t_capture.join()
+        t_worker.join()

--- a/quiz_automation/stats.py
+++ b/quiz_automation/stats.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+"""Runtime statistics for quiz automation."""
+
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class Stats:
+    """Container tracking per-question metrics.
+
+    The object stores lightweight statistics that can be safely updated from
+    worker threads without additional locking because all operations mutate
+    primitive types or append to lists.  Consumers such as the GUI read the
+    aggregated properties like :attr:`questions_answered` or
+    :attr:`average_time` to display live metrics.
+    """
+
+    question_times: List[float] = field(default_factory=list)
+    token_counts: List[int] = field(default_factory=list)
+    questions_answered: int = 0
+    errors: int = 0
+
+    def record(self, duration: float, tokens: int) -> None:
+        """Record timing and token usage for a successful question."""
+
+        self.questions_answered += 1
+        self.question_times.append(duration)
+        self.token_counts.append(tokens)
+
+    def record_error(self) -> None:
+        """Increment the error counter."""
+
+        self.errors += 1
+
+    @property
+    def average_time(self) -> float:
+        """Return the average time taken per question."""
+
+        if not self.question_times:
+            return 0.0
+        return sum(self.question_times) / len(self.question_times)
+
+    @property
+    def average_tokens(self) -> float:
+        """Return the average tokens used per question."""
+
+        if not self.token_counts:
+            return 0.0
+        return sum(self.token_counts) / len(self.token_counts)

--- a/quiz_automation/watcher.py
+++ b/quiz_automation/watcher.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+"""Monitor the screen for new quiz questions and emit events."""
+
+import threading
+import time
+from queue import Queue
+from typing import Tuple
+
+from .config import Settings
+from .utils import hash_text
+
+try:  # pragma: no cover - optional dependency
+    from mss import mss
+except Exception:  # pragma: no cover
+    mss = None  # type: ignore
+
+
+def _mss():  # pragma: no cover - tiny wrapper for easier monkeypatching
+    if mss is None:
+        raise RuntimeError("mss not available")
+    return mss
+
+
+class Watcher(threading.Thread):
+    """Background thread that polls the screen for new questions."""
+
+    def __init__(self, region: Tuple[int, int, int, int], queue: Queue, cfg: Settings) -> None:
+        super().__init__(daemon=True)
+        self.region = region
+        self.queue = queue
+        self.cfg = cfg
+        self.stop_flag = threading.Event()
+        self.pause_flag = threading.Event()
+        self._last_hash: str | None = None
+
+    # -- basic helpers -------------------------------------------------
+    def capture(self):  # pragma: no cover - trivial wrapper
+        return _mss().mss().grab(self.region)
+
+    def ocr(self, img) -> str:  # pragma: no cover - placeholder for tests
+        return ""
+
+    def is_new_question(self, text: str) -> bool:
+        current = hash_text(text)
+        if current != self._last_hash:
+            self._last_hash = current
+            return True
+        return False
+
+    # -- thread control ------------------------------------------------
+    def stop(self) -> None:
+        self.stop_flag.set()
+
+    def pause(self) -> None:
+        self.pause_flag.set()
+
+    def resume(self) -> None:
+        self.pause_flag.clear()
+
+    # -- main loop -----------------------------------------------------
+    def run(self) -> None:  # pragma: no cover - behaviour exercised in tests
+        while not self.stop_flag.is_set():
+            if self.pause_flag.is_set():
+                time.sleep(self.cfg.poll_interval)
+                continue
+            img = self.capture()
+            text = self.ocr(img)
+            if self.is_new_question(text):
+                self.queue.put(("question", img, text))
+            time.sleep(self.cfg.poll_interval)


### PR DESCRIPTION
## Summary
- implement Stats dataclass to track question timings, tokens, and errors
- add PySide6-based QuizGUI for live metric display
- build producer/consumer pipeline in QuizRunner
- expose automation helpers for ChatGPT interaction and stats updates
- provide Watcher thread for screen polling and a simple Settings configuration

## Testing
- `pytest tests/test_config.py tests/test_chatgpt_client.py tests/test_runner.py tests/test_cv_expert.py tests/test_utils.py tests/test_watcher.py -q`
- `python -m pytest` *(fails: SyntaxError in tests/test_stats.py)*

------
https://chatgpt.com/codex/tasks/task_e_68943b8dd4388328ae120a027faebbcd