### PR TITLE
Implement quiz automation helpers and region selector

### DIFF
--- a/quiz_automation/region_selector.py
+++ b/quiz_automation/region_selector.py
@@ -1,0 +1,73 @@
+"""Helper for manually selecting and persisting screen regions.
+
+The real project relies on :mod:`pyautogui` to read the mouse position while a
+user hovers over different corners of the desired region.  For the purposes of
+the tests, ``pyautogui`` is optional and substituted with a minimal stub when it
+cannot be imported.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Tuple
+import json
+
+try:  # pragma: no cover - optional dependency
+    import pyautogui  # type: ignore
+except Exception:  # pragma: no cover
+    from types import SimpleNamespace
+
+    pyautogui = SimpleNamespace(position=lambda: (0, 0))  # type: ignore[attr-defined]
+
+
+@dataclass
+class RegionSelector:
+    """Persist and recall screen regions.
+
+    Parameters
+    ----------
+    path:
+        Location of the JSON file used to store named regions.
+    """
+
+    path: Path
+    _regions: Dict[str, Tuple[int, int, int, int]] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.path.exists():
+            with self.path.open("r", encoding="utf8") as fh:
+                data = json.load(fh)
+                self._regions = {k: tuple(v) for k, v in data.items()}
+
+    def select(self, name: str) -> Tuple[int, int, int, int]:
+        """Interactively select a region and persist it under ``name``.
+
+        The user is prompted (via :func:`input`) to move the mouse to the top
+        left and then the bottom right corner of the region.  The coordinates are
+        measured using :func:`pyautogui.position`.
+        """
+
+        input("Move mouse to top left and press Enter")
+        x1, y1 = pyautogui.position()
+        input("Move mouse to bottom right and press Enter")
+        x2, y2 = pyautogui.position()
+        region = (x1, y1, x2 - x1, y2 - y1)
+
+        self._regions[name] = region
+        with self.path.open("w", encoding="utf8") as fh:
+            json.dump(self._regions, fh)
+
+        return region
+
+    def load(self, name: str) -> Tuple[int, int, int, int]:
+        """Return the region stored under ``name``.
+
+        Raises
+        ------
+        KeyError
+            If the region ``name`` has not been saved yet.
+        """
+
+        return self._regions[name]
+

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,1 +1,24 @@
-\
+"""Tests for :mod:`quiz_automation.stats`."""
+
+from quiz_automation.stats import Stats
+import pytest
+
+
+def test_record_updates_counts_and_averages() -> None:
+    stats = Stats()
+    stats.record(1.0, 4)
+    stats.record(2.0, 6)
+
+    assert stats.questions_answered == 2
+    # Average of [1.0, 2.0]
+    assert stats.average_time == pytest.approx(1.5)
+    # Average of [4, 6]
+    assert stats.average_tokens == pytest.approx(5.0)
+
+
+def test_record_error_increments_error_counter() -> None:
+    stats = Stats()
+    stats.record_error()
+    stats.record_error()
+    assert stats.errors == 2
+


### PR DESCRIPTION
## Summary
- Add fully documented `automation` module exposing helpers like `answer_question_via_chatgpt` with graceful fallbacks when UI libraries are missing
- Implement `RegionSelector` to persist screen regions using `pyautogui` with optional stub
- Provide tests for `Stats` and ensure ruff linting and full test suite pass

## Testing
- `python -m ruff check quiz_automation/automation.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68971624edec83289b7e0d4cef16e625