### PR TITLE
Add environment-based settings loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Basic AI Auto Assistant
+
+## Setup
+
+The application reads configuration from environment variables. The most
+important ones are:
+
+| Variable | Description | Default |
+|---------|-------------|---------|
+| `OPENAI_API_KEY` | API key for OpenAI requests. | _unset_ |
+| `POLL_INTERVAL` | Delay (in seconds) between polling iterations. | `1.0` |
+
+Set them before running the scripts, for example:
+
+```bash
+export OPENAI_API_KEY="sk-..."
+export POLL_INTERVAL=2.5  # optional
+```
+
+The `POLL_INTERVAL` variable is optional. If not provided, the system falls
+back to a default of one second between polls.
+

--- a/quiz_automation/config.py
+++ b/quiz_automation/config.py
@@ -1,17 +1,32 @@
-from __future__ import annotations
-
 """Configuration handling for the quiz automation package."""
 
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
 
 
-class Settings(BaseSettings):
-    """Read configuration from environment variables."""
+@dataclass
+class Settings:
+    """Configuration loaded from environment variables.
 
-    openai_api_key: str | None = None
-    poll_interval: float = 1.0
+    Attributes
+    ----------
+    openai_api_key:
+        API key used by the OpenAI client. Defaults to the value of the
+        ``OPENAI_API_KEY`` environment variable, or ``None`` when the variable
+        is unset.
+    poll_interval:
+        Delay, in seconds, between polling iterations. Defaults to the value
+        of ``POLL_INTERVAL`` if set, otherwise ``1.0``.
+    """
 
-    model_config = SettingsConfigDict(env_prefix="", extra="ignore")
+    openai_api_key: str | None = field(
+        default_factory=lambda: os.getenv("OPENAI_API_KEY")
+    )
+    poll_interval: float = field(
+        default_factory=lambda: float(os.getenv("POLL_INTERVAL", "1.0"))
+    )
 
 
 # A module-level settings instance convenient for components that do not need

--- a/quiz_automation/region_selector.py
+++ b/quiz_automation/region_selector.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+"""Utility to capture and persist screen regions."""
+
+from pathlib import Path
+import json
+
+try:  # pragma: no cover - best effort for environments without a display
+    import pyautogui  # type: ignore
+except Exception:  # pragma: no cover
+    from types import SimpleNamespace
+
+    pyautogui = SimpleNamespace(position=lambda: (0, 0))  # type: ignore
+
+
+class RegionSelector:
+    """Select rectangular screen regions and persist them to disk."""
+
+    def __init__(self, path: Path):
+        self.path = Path(path)
+        if self.path.exists():
+            raw = json.loads(self.path.read_text())
+            self._regions = {k: tuple(v) for k, v in raw.items()}
+        else:
+            self._regions = {}
+
+    def select(self, name: str) -> tuple[int, int, int, int]:
+        """Interactively capture a region and store it under ``name``."""
+
+        input("Move cursor to top-left and press Enter")
+        x1, y1 = pyautogui.position()
+        input("Move cursor to bottom-right and press Enter")
+        x2, y2 = pyautogui.position()
+        region = (x1, y1, x2 - x1, y2 - y1)
+        self._regions[name] = region
+        self._save()
+        return region
+
+    def load(self, name: str) -> tuple[int, int, int, int] | None:
+        """Return the stored region named ``name`` if present."""
+
+        region = self._regions.get(name)
+        if region is not None:
+            return tuple(region)
+        return None
+
+    def _save(self) -> None:
+        serializable = {k: list(v) for k, v in self._regions.items()}
+        self.path.write_text(json.dumps(serializable))
+

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,1 +1,24 @@
-\
+from quiz_automation.stats import Stats
+
+
+def test_record_and_average():
+    stats = Stats()
+    stats.record(2.0, 10)
+    stats.record(4.0, 20)
+
+    assert stats.questions_answered == 2
+    assert stats.errors == 0
+    assert stats.average_time == 3.0
+    assert stats.average_tokens == 15.0
+
+
+def test_record_error():
+    stats = Stats()
+    stats.record_error()
+    stats.record_error()
+
+    assert stats.errors == 2
+    assert stats.questions_answered == 0
+    assert stats.average_time == 0.0
+    assert stats.average_tokens == 0.0
+


### PR DESCRIPTION
## Summary
- load `OPENAI_API_KEY` and `POLL_INTERVAL` from environment via a `Settings` dataclass
- document required environment variables
- provide minimal region selector and stats tests so the suite runs

## Testing
- `python -m ruff check quiz_automation/config.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897162623288328812b9914df646132