### PR TITLE
Add watcher and automation modules with tests and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt flake8 black mypy
+      - name: Lint
+        run: |
+          flake8
+          black --check .
+          mypy quiz_automation
+      - name: Test
+        run: pytest -q

--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# Basic AI Auto Assistant
+
+A minimal, test-focused project that demonstrates how a desktop quiz helper
+could integrate screen capture, OCR and the ChatGPT API.  The real application
+would automate reading quiz questions from the screen, querying ChatGPT for an
+answer and clicking the corresponding option.
+
+## Setup
+
+Requirements are listed in `requirements.txt`.  Create a virtual environment and
+install them with
+
+```bash
+pip install -r requirements.txt
+```
+
+Some dependencies such as `pyautogui` and `mss` interact with the system GUI.
+The unit tests mock these modules so they can run headlessly.
+
+## Configuration
+
+Runtime behaviour is controlled through environment variables:
+
+- `OPENAI_API_KEY` – API key used by the ChatGPT client.
+- `POLL_INTERVAL` – interval in seconds between screen polls (default `1.0`).
+- `READ_TIMEOUT` – timeout for reading ChatGPT responses (default `20.0`).
+- `CLICK_OFFSET` – pixel distance between answer options (default `40`).
+
+## Running tests
+
+All tests are written with `pytest` and can be executed headlessly:
+
+```bash
+pytest -q
+```
+
+## Contributing
+
+Code should follow PEP 8 guidelines and include type hints.  The project uses
+`black`, `flake8` and `mypy` for formatting and linting.  A GitHub Actions
+workflow runs these tools along with the test suite for every commit.

--- a/quiz_automation/automation.py
+++ b/quiz_automation/automation.py
@@ -1,1 +1,122 @@
-=
+"""High level helpers orchestrating the quiz answering flow."""
+from __future__ import annotations
+
+import logging
+import re
+import time
+from typing import Sequence, Tuple
+
+try:  # pragma: no cover - optional GUI dependencies
+    import pyautogui  # type: ignore
+except Exception:  # pragma: no cover
+    from types import SimpleNamespace
+
+    pyautogui = SimpleNamespace(
+        click=lambda *a, **k: None,
+        hotkey=lambda *a, **k: None,
+        press=lambda *a, **k: None,
+        screenshot=lambda *a, **k: None,
+        moveTo=lambda *a, **k: None,
+    )
+
+try:  # pragma: no cover
+    import pytesseract  # type: ignore
+except Exception:  # pragma: no cover
+    from types import SimpleNamespace
+
+    pytesseract = SimpleNamespace(image_to_string=lambda img: "")
+
+from .config import settings
+from .utils import copy_image_to_clipboard
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Low level helpers
+
+
+def click_option(base: Tuple[int, int], index: int, offset: int | None = None) -> None:
+    """Click the answer option at ``base`` plus ``index`` * offset."""
+
+    y_offset = (offset or settings.click_offset) * index
+    x, y = base
+    try:
+        pyautogui.click(x, y + y_offset)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("click failed: %s", exc)
+        raise
+
+
+def send_to_chatgpt(image, box: Tuple[int, int]) -> None:
+    """Paste ``image`` into the ChatGPT text box located at ``box``."""
+
+    try:
+        copy_image_to_clipboard(image)
+        pyautogui.click(*box)
+        pyautogui.hotkey("ctrl", "v")
+        pyautogui.press("enter")
+    except Exception as exc:  # pragma: no cover
+        logger.debug("send_to_chatgpt failed: %s", exc)
+        raise
+
+
+def read_chatgpt_response(region: Tuple[int, int, int, int], timeout: float | None = None) -> str:
+    """Poll ``region`` until OCR returns text or ``timeout`` expires."""
+
+    end = time.time() + (timeout or settings.read_timeout)
+    while time.time() < end:
+        try:
+            img = pyautogui.screenshot(region=region)
+            text = pytesseract.image_to_string(img).strip()
+        except Exception as exc:  # pragma: no cover
+            logger.debug("read_chatgpt_response failed: %s", exc)
+            text = ""
+        if text:
+            return text
+        time.sleep(0.5)
+    raise TimeoutError("no response")
+
+
+# ---------------------------------------------------------------------------
+# High level flow
+
+
+def _parse_answer(text: str, options: Sequence[str]) -> Tuple[str, int]:
+    """Extract the option letter from *text* and return it and its index."""
+
+    match = re.search(r"([A-Z])", text.upper())
+    if not match:
+        raise ValueError("no option letter found")
+    letter = match.group(1)
+    return letter, options.index(letter)
+
+
+def answer_question_via_chatgpt(
+    question_region: Tuple[int, int, int, int],
+    chatgpt_box: Tuple[int, int],
+    response_region: Tuple[int, int, int, int],
+    options: Sequence[str],
+    option_base: Tuple[int, int],
+    *,
+    retries: int = 3,
+) -> str:
+    """Capture the question, send it to ChatGPT and click the returned option."""
+
+    image = pyautogui.screenshot(region=question_region)
+    question = pytesseract.image_to_string(image)
+    send_to_chatgpt(question, chatgpt_box)
+
+    for attempt in range(retries):
+        try:
+            text = read_chatgpt_response(response_region)
+            letter, idx = _parse_answer(text, options)
+            click_option(option_base, idx)
+            return letter
+        except TimeoutError:
+            if attempt == retries - 1:
+                raise
+            time.sleep(2 ** attempt)
+
+    # Should never reach here
+    raise TimeoutError("no response")

--- a/quiz_automation/config.py
+++ b/quiz_automation/config.py
@@ -1,0 +1,30 @@
+"""Application configuration and defaults."""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class Settings:
+    """Runtime settings loaded from environment variables.
+
+    Environment variables are read at instantiation time so tests can modify
+    them via ``monkeypatch``.
+    """
+
+    openai_api_key: str = ""
+    poll_interval: float = 1.0
+    read_timeout: float = 20.0
+    click_offset: int = 40
+
+    def __post_init__(self) -> None:  # pragma: no cover - trivial
+        self.openai_api_key = os.getenv("OPENAI_API_KEY", self.openai_api_key)
+        self.poll_interval = float(os.getenv("POLL_INTERVAL", self.poll_interval))
+        self.read_timeout = float(os.getenv("READ_TIMEOUT", self.read_timeout))
+        self.click_offset = int(os.getenv("CLICK_OFFSET", self.click_offset))
+
+
+# A module level instance is convenient for small scripts and mirrors how the
+# rest of the project expects settings to be accessed.
+settings = Settings()

--- a/quiz_automation/region_selector.py
+++ b/quiz_automation/region_selector.py
@@ -1,0 +1,55 @@
+"""Utilities for interactively selecting screen regions."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Tuple
+
+try:  # pragma: no cover - optional GUI dependency
+    import pyautogui  # type: ignore
+except Exception:  # pragma: no cover
+    from types import SimpleNamespace
+
+    pyautogui = SimpleNamespace(position=lambda: (0, 0))
+
+from .utils import validate_region
+
+
+class RegionSelector:
+    """Persist user defined screen regions to a JSON file.
+
+    The real application would likely provide a GUI for region selection.  For
+    testing purposes we simply ask the user to position the mouse cursor at two
+    corners of the desired region and press ``Enter`` after each move.
+    """
+
+    def __init__(self, storage: Path) -> None:
+        self.storage = Path(storage)
+        self._coords: Dict[str, Tuple[int, int, int, int]] = {}
+        if self.storage.exists():
+            try:
+                data = json.loads(self.storage.read_text())
+                for k, v in data.items():
+                    self._coords[k] = tuple(v)  # type: ignore[arg-type]
+            except Exception:
+                self._coords = {}
+
+    # ------------------------------------------------------------------
+    def select(self, name: str) -> Tuple[int, int, int, int]:
+        """Interactively gather two points and store the resulting region."""
+
+        input("Move cursor to top-left and press Enter")
+        x1, y1 = pyautogui.position()
+        input("Move cursor to bottom-right and press Enter")
+        x2, y2 = pyautogui.position()
+        region = (x1, y1, x2 - x1, y2 - y1)
+        validate_region(region)
+        self._coords[name] = region
+        self.storage.write_text(json.dumps(self._coords))
+        return region
+
+    # ------------------------------------------------------------------
+    def load(self, name: str) -> Tuple[int, int, int, int] | None:
+        """Return a previously stored region or ``None`` if missing."""
+
+        return self._coords.get(name)

--- a/quiz_automation/stats.py
+++ b/quiz_automation/stats.py
@@ -1,0 +1,21 @@
+"""Simple helper for tracking quiz performance."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Stats:
+    """Track number of questions asked and how many were correct."""
+
+    asked: int = 0
+    correct: int = 0
+
+    def record(self, is_correct: bool) -> None:
+        self.asked += 1
+        if is_correct:
+            self.correct += 1
+
+    @property
+    def accuracy(self) -> float:
+        return self.correct / self.asked if self.asked else 0.0

--- a/quiz_automation/watcher.py
+++ b/quiz_automation/watcher.py
@@ -1,0 +1,106 @@
+"""Screen watcher thread that emits OCR'd quiz questions."""
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from queue import Queue
+from typing import Any, Callable, Optional, Tuple
+
+from .config import Settings
+from .utils import hash_text
+
+logger = logging.getLogger(__name__)
+
+
+# Delayed imports wrapped for ease of monkeypatching in tests
+
+def _mss():  # pragma: no cover - thin wrapper
+    import mss
+
+    return mss
+
+
+def _pytesseract():  # pragma: no cover - thin wrapper
+    import pytesseract
+
+    return pytesseract
+
+
+class Watcher(threading.Thread):
+    """Periodically capture a region of the screen and emit new questions."""
+
+    def __init__(
+        self,
+        region: Tuple[int, int, int, int],
+        event_queue: Queue,
+        cfg: Settings,
+        capture_fn: Optional[Callable[[], Any]] = None,
+        ocr_fn: Optional[Callable[[Any], str]] = None,
+    ) -> None:
+        super().__init__(daemon=True)
+        self.region = region
+        self.queue = event_queue
+        self.cfg = cfg
+        self.stop_flag = threading.Event()
+        self.paused = threading.Event()
+        self._last_hash: Optional[str] = None
+
+        if capture_fn is not None:
+            self.capture = capture_fn
+        else:
+            sct_module = _mss()
+            sct = sct_module.mss()
+
+            def _cap() -> Any:
+                return sct.grab(self.region)
+
+            self.capture = _cap
+
+        if ocr_fn is not None:
+            self.ocr = ocr_fn
+        else:
+            def _ocr(img: Any) -> str:
+                return _pytesseract().image_to_string(img)
+
+            self.ocr = _ocr
+
+    # ------------------------------------------------------------------
+    def is_new_question(self, text: str) -> bool:
+        """Return ``True`` if *text* has not been seen before."""
+
+        digest = hash_text(text)
+        if digest == self._last_hash:
+            return False
+        self._last_hash = digest
+        return True
+
+    # ------------------------------------------------------------------
+    def run(self) -> None:
+        while not self.stop_flag.is_set():
+            if self.paused.is_set():
+                time.sleep(self.cfg.poll_interval)
+                continue
+
+            try:
+                img = self.capture()
+                text = self.ocr(img)
+            except Exception as exc:  # pragma: no cover - safety net
+                logger.debug("capture/ocr failed: %s", exc)
+                time.sleep(self.cfg.poll_interval)
+                continue
+
+            if self.is_new_question(text):
+                self.queue.put(("question", text))
+
+            time.sleep(self.cfg.poll_interval)
+
+    # ------------------------------------------------------------------
+    def pause(self) -> None:
+        self.paused.set()
+
+    def resume(self) -> None:
+        self.paused.clear()
+
+    def stop(self) -> None:
+        self.stop_flag.set()

--- a/tests/test_chatgpt_flow.py
+++ b/tests/test_chatgpt_flow.py
@@ -1,0 +1,83 @@
+import pytest
+
+from quiz_automation import automation, chatgpt_client
+
+
+def test_click_option_uses_offset(monkeypatch):
+    """click_option should offset the click based on the index."""
+    coords = {}
+
+    def fake_click(x, y):
+        coords["pt"] = (x, y)
+
+    monkeypatch.setattr(automation.pyautogui, "click", fake_click)
+    automation.click_option((100, 200), 2, offset=30)
+    assert coords["pt"] == (100, 200 + 2 * 30)
+
+
+def test_answer_question_retries_on_timeout(monkeypatch):
+    """answer_question_via_chatgpt should retry when reading times out."""
+    monkeypatch.setattr(automation.pyautogui, "screenshot", lambda region=None: "img")
+    monkeypatch.setattr(automation.pytesseract, "image_to_string", lambda img: "Q?")
+    monkeypatch.setattr(automation, "send_to_chatgpt", lambda img, box: None)
+    monkeypatch.setattr(chatgpt_client, "OpenAI", lambda api_key=None: object())
+
+    calls = {"read": 0}
+
+    def fake_read(region, timeout=20.0):
+        calls["read"] += 1
+        if calls["read"] < 2:
+            raise TimeoutError("no response")
+        return "Answer A"
+
+    monkeypatch.setattr(automation, "read_chatgpt_response", fake_read)
+
+    clicked = {}
+
+    def fake_click(base, idx, offset=40):
+        clicked["idx"] = idx
+
+    monkeypatch.setattr(automation, "click_option", fake_click)
+    result = automation.answer_question_via_chatgpt(
+        (0, 0, 10, 10), (0, 0), (0, 0, 10, 10), ["A", "B", "C", "D"], (0, 0)
+    )
+    assert result == "A"
+    assert calls["read"] == 2
+    assert clicked["idx"] == 0
+
+
+def test_answer_question_fails_after_retries(monkeypatch):
+    """When all retries fail, an error should be raised."""
+    monkeypatch.setattr(automation.pyautogui, "screenshot", lambda region=None: "img")
+    monkeypatch.setattr(automation.pytesseract, "image_to_string", lambda img: "Q?")
+    monkeypatch.setattr(automation, "send_to_chatgpt", lambda img, box: None)
+    monkeypatch.setattr(automation, "click_option", lambda base, idx, offset=40: None)
+
+    def always_timeout(region, timeout=20.0):
+        raise TimeoutError("no response")
+
+    monkeypatch.setattr(automation, "read_chatgpt_response", always_timeout)
+    with pytest.raises(TimeoutError):
+        automation.answer_question_via_chatgpt(
+            (0, 0, 10, 10), (0, 0), (0, 0, 10, 10), ["A", "B"], (0, 0)
+        )
+
+
+def test_chatgpt_timeout_retry(monkeypatch):
+    """ChatGPTClient should retry and raise after repeated timeouts."""
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+
+    class FailingOpenAI:
+        def __init__(self, api_key=None):
+            pass
+
+        class responses:  # type: ignore
+            @staticmethod
+            def create(**kwargs):
+                raise TimeoutError("boom")
+
+    monkeypatch.setattr(chatgpt_client, "OpenAI", FailingOpenAI)
+    client = chatgpt_client.ChatGPTClient()
+    with pytest.raises(RuntimeError):
+        client.ask("Q?", retries=2)
+

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,1 +1,10 @@
-\
+from quiz_automation.stats import Stats
+
+
+def test_stats_records_accuracy():
+    s = Stats()
+    s.record(True)
+    s.record(False)
+    assert s.asked == 2
+    assert s.correct == 1
+    assert abs(s.accuracy - 0.5) < 1e-6

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -1,9 +1,12 @@
 import time
 from queue import Queue
 
+import pytest
+
 from quiz_automation import watcher as watcher_module
 from quiz_automation.config import Settings
 from quiz_automation.watcher import Watcher
+from quiz_automation.region_selector import RegionSelector
 
 
 class DummyMSS:
@@ -61,3 +64,54 @@ def test_watcher_pause_resume(monkeypatch):
     w.resume()
     w.join()
     assert not q.empty()
+
+
+def test_watcher_no_event_for_duplicate(monkeypatch):
+    """Watcher should not emit events for repeated questions."""
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    monkeypatch.setattr(
+        watcher_module,
+        "_mss",
+        lambda: type("S", (), {"mss": lambda self=None: DummyMSS()})(),
+    )
+    cfg = Settings()
+    q: Queue = Queue()
+    w = Watcher((0, 0, 1, 1), q, cfg)
+    monkeypatch.setattr(w, "capture", lambda: "img")
+    monkeypatch.setattr(w, "ocr", lambda img: "text")
+    monkeypatch.setattr(w, "is_new_question", lambda text: False)
+
+    def fake_sleep(_):
+        w.stop_flag.set()
+
+    monkeypatch.setattr("quiz_automation.watcher.time.sleep", fake_sleep)
+    w.run()
+    assert q.empty()
+
+
+def test_region_calibration_success(monkeypatch, tmp_path):
+    """RegionSelector should compute coordinates from two positions."""
+    path = tmp_path / "coords.json"
+    selector = RegionSelector(path)
+    positions = iter([(10, 20), (50, 80)])
+    monkeypatch.setattr("builtins.input", lambda prompt="": None)
+    monkeypatch.setattr(
+        "quiz_automation.region_selector.pyautogui.position",
+        lambda: next(positions),
+    )
+    region = selector.select("quiz")
+    assert region == (10, 20, 40, 60)
+
+
+def test_region_calibration_failure(monkeypatch, tmp_path):
+    """RegionSelector should raise when user does not provide two points."""
+    path = tmp_path / "coords.json"
+    selector = RegionSelector(path)
+    positions = iter([(1, 2)])  # only one point provided
+    monkeypatch.setattr("builtins.input", lambda prompt="": None)
+    monkeypatch.setattr(
+        "quiz_automation.region_selector.pyautogui.position",
+        lambda: next(positions),
+    )
+    with pytest.raises(StopIteration):
+        selector.select("quiz")


### PR DESCRIPTION
## Summary
- implement Settings dataclass and core automation helpers with retry logic
- add region selector, watcher thread, and stats tracking modules
- document setup and add GitHub Actions workflow for linting and tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68943b8ee9548328a4dfd18fe13de5e0