### PR TITLE
Guard Stats with locking and add concurrent tests

### DIFF
--- a/quiz_automation/stats.py
+++ b/quiz_automation/stats.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 """Runtime statistics for quiz automation."""
 
 from dataclasses import dataclass, field
+from threading import Lock
 from typing import List
 
 
@@ -10,42 +11,46 @@ from typing import List
 class Stats:
     """Container tracking per-question metrics.
 
-    The object stores lightweight statistics that can be safely updated from
-    worker threads without additional locking because all operations mutate
-    primitive types or append to lists.  Consumers such as the GUI read the
-    aggregated properties like :attr:`questions_answered` or
-    :attr:`average_time` to display live metrics.
+    The object internally protects its mutable state with a :class:`~threading.Lock`
+    so that worker threads can safely update statistics concurrently. Consumers
+    such as the GUI read the aggregated properties like
+    :attr:`questions_answered` or :attr:`average_time` to display live metrics.
     """
 
     question_times: List[float] = field(default_factory=list)
     token_counts: List[int] = field(default_factory=list)
     questions_answered: int = 0
     errors: int = 0
+    _lock: Lock = field(default_factory=Lock, init=False, repr=False)
 
     def record(self, duration: float, tokens: int) -> None:
         """Record timing and token usage for a successful question."""
 
-        self.questions_answered += 1
-        self.question_times.append(duration)
-        self.token_counts.append(tokens)
+        with self._lock:
+            self.questions_answered += 1
+            self.question_times.append(duration)
+            self.token_counts.append(tokens)
 
     def record_error(self) -> None:
         """Increment the error counter."""
 
-        self.errors += 1
+        with self._lock:
+            self.errors += 1
 
     @property
     def average_time(self) -> float:
         """Return the average time taken per question."""
 
-        if not self.question_times:
-            return 0.0
-        return sum(self.question_times) / len(self.question_times)
+        with self._lock:
+            if not self.question_times:
+                return 0.0
+            return sum(self.question_times) / len(self.question_times)
 
     @property
     def average_tokens(self) -> float:
         """Return the average tokens used per question."""
 
-        if not self.token_counts:
-            return 0.0
-        return sum(self.token_counts) / len(self.token_counts)
+        with self._lock:
+            if not self.token_counts:
+                return 0.0
+            return sum(self.token_counts) / len(self.token_counts)

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -2,6 +2,7 @@
 
 from quiz_automation.stats import Stats
 import pytest
+from concurrent.futures import ThreadPoolExecutor
 
 
 def test_record_updates_counts_and_averages() -> None:
@@ -21,4 +22,28 @@ def test_record_error_increments_error_counter() -> None:
     stats.record_error()
     stats.record_error()
     assert stats.errors == 2
+
+
+def test_concurrent_updates_thread_safe() -> None:
+    stats = Stats()
+
+    def do_record() -> None:
+        stats.record(1.0, 1)
+
+    def do_error() -> None:
+        stats.record_error()
+
+    total_records = 20
+    total_errors = 10
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        for _ in range(total_records):
+            executor.submit(do_record)
+        for _ in range(total_errors):
+            executor.submit(do_error)
+
+    assert stats.questions_answered == total_records
+    assert stats.errors == total_errors
+    assert stats.average_time == pytest.approx(1.0)
+    assert stats.average_tokens == pytest.approx(1.0)
 


### PR DESCRIPTION
## Summary
- Protect mutable stats fields with an internal `threading.Lock`
- Update Stat methods to acquire lock for safe concurrent mutations
- Add tests exercising concurrent updates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a8e2850cc8328a4ef88aa0ea997fc