### PR TITLE
Add configurable logger and integrate with automation components

### DIFF
--- a/quiz_automation/automation.py
+++ b/quiz_automation/automation.py
@@ -35,6 +35,9 @@ except Exception:  # pragma: no cover
 
 from .utils import copy_image_to_clipboard, validate_region
 from .stats import Stats
+from .logger import get_logger
+
+logger = get_logger(__name__)
 
 __all__ = [
     "send_to_chatgpt",
@@ -155,6 +158,7 @@ def answer_question_via_chatgpt(
 
     # The model typically ends its reply with something like "Answer: B".
     letter = response.strip().split()[-1].upper() if response else "A"
+    logger.info("ChatGPT chose %s", letter)
     try:
         idx = options.index(letter)
     except ValueError:

--- a/quiz_automation/logger.py
+++ b/quiz_automation/logger.py
@@ -1,0 +1,43 @@
+import inspect
+import logging
+from typing import Optional
+
+DEFAULT_FORMAT = "%(levelname)s:%(name)s:%(message)s"
+
+
+def configure_logger(level: int = logging.INFO, fmt: str = DEFAULT_FORMAT) -> logging.Logger:
+    """Configure and return the root logger for the package.
+
+    Parameters
+    ----------
+    level:
+        Logging level to be applied to the package logger.
+    fmt:
+        Formatter string used for the attached :class:`logging.StreamHandler`.
+    """
+    logger = logging.getLogger("quiz_automation")
+    logger.setLevel(level)
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter(fmt))
+    logger.handlers.clear()
+    logger.addHandler(handler)
+    return logger
+
+
+def get_logger(name: Optional[str] = None) -> logging.Logger:
+    """Return a logger bound to *name* or the caller's module.
+
+    When *name* is ``None`` the module name of the caller is used.  This mirrors
+    the common pattern ``logging.getLogger(__name__)`` while avoiding repetition
+    in modules that want a logger associated with their ``__name__``.
+    """
+    if name is None:
+        frame = inspect.stack()[1]
+        name = frame.frame.f_globals.get("__name__", "quiz_automation")
+    return logging.getLogger(name)
+
+
+# Configure the package logger with default settings on import so that modules
+# can immediately log messages.  Tests or applications can call
+# :func:`configure_logger` again to customise behaviour.
+configure_logger()

--- a/quiz_automation/runner.py
+++ b/quiz_automation/runner.py
@@ -10,6 +10,9 @@ from . import automation
 from .automation import answer_question_via_chatgpt
 from .stats import Stats
 from .gui import QuizGUI
+from .logger import get_logger
+
+logger = get_logger(__name__)
 
 
 class QuizRunner(threading.Thread):
@@ -65,6 +68,7 @@ class QuizRunner(threading.Thread):
                         stats=self.stats,
                     )
                 except Exception:
+                    logger.exception("Error while answering question")
                     self.stats.record_error()
                 finally:
                     if self.gui is not None:

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,33 @@
+import logging
+
+from quiz_automation.logger import configure_logger, get_logger
+from quiz_automation import automation
+
+
+def test_configure_logger_and_format(capsys):
+    fmt = "%(levelname)s|%(name)s|%(message)s"
+    configure_logger(level=logging.DEBUG, fmt=fmt)
+    log = get_logger("quiz_automation.test")
+    log.debug("hello")
+    assert capsys.readouterr().err.strip() == "DEBUG|quiz_automation.test|hello"
+
+
+def test_get_logger_defaults_to_caller_module():
+    configure_logger()
+    log = get_logger()
+    assert log.name == __name__
+
+
+def test_automation_logs_message(monkeypatch, caplog):
+    configure_logger(level=logging.INFO, fmt="%(message)s")
+    caplog.set_level(logging.INFO, logger="quiz_automation.automation")
+
+    monkeypatch.setattr(automation, "send_to_chatgpt", lambda img, box: None)
+    monkeypatch.setattr(automation, "read_chatgpt_response", lambda region, timeout=20.0: "Answer B")
+    monkeypatch.setattr(automation, "click_option", lambda base, idx, offset=40: None)
+
+    letter = automation.answer_question_via_chatgpt(
+        "img", (0, 0), (0, 0, 10, 10), ["A", "B"], (0, 0)
+    )
+    assert letter == "B"
+    assert "ChatGPT chose B" in caplog.text


### PR DESCRIPTION
## Summary
- Introduce `logger` module with configurable level and format and helper for module loggers
- Use the new logger in automation and runner modules for informational and error messages
- Add tests verifying logger configuration, default naming, and log emission from automation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a8e2642dc832893f99975bf4b4bfa