### PR TITLE
Add clicker wrapper and tests

### DIFF
--- a/quiz_automation/clicker.py
+++ b/quiz_automation/clicker.py
@@ -1,0 +1,72 @@
+"""Lightweight helpers for moving the mouse and performing clicks.
+
+The project normally relies on :mod:`pyautogui` for desktop automation.  The
+tests in this kata run in a minimal environment where the dependency may not be
+installed, so this module mirrors the graceful fallback approach used in
+``automation.py``.  A very small stand‑in object provides the attributes used
+here which allows the functions to be imported and monkeypatched for unit
+tests.
+"""
+
+from __future__ import annotations
+
+try:  # pragma: no cover - optional heavy dependency
+    import pyautogui  # type: ignore
+except Exception:  # pragma: no cover
+    # ``pyautogui`` is not available.  Provide a minimal mock so the rest of the
+    # code can still be exercised.  Each attribute mirrors the functions used in
+    # this module and can be monkeypatched in tests if required.
+    from types import SimpleNamespace
+
+    pyautogui = SimpleNamespace(  # type: ignore[attr-defined]
+        moveTo=lambda *_, **__: None,
+        click=lambda *_, **__: None,
+    )
+
+__all__ = ["Clicker", "move_to", "click", "click_at"]
+
+
+class Clicker:
+    """Encapsulate mouse movement and clicking via :mod:`pyautogui`."""
+
+    def move(self, x: int, y: int) -> None:
+        """Move the mouse cursor to ``(x, y)``."""
+
+        if not hasattr(pyautogui, "moveTo"):
+            raise RuntimeError("pyautogui not available")
+        pyautogui.moveTo(x, y)
+
+    def click(self) -> None:
+        """Perform a mouse click at the current cursor location."""
+
+        if not hasattr(pyautogui, "click"):
+            raise RuntimeError("pyautogui not available")
+        pyautogui.click()
+
+    def click_at(self, x: int, y: int) -> None:
+        """Move the mouse to ``(x, y)`` and click."""
+
+        self.move(x, y)
+        self.click()
+
+
+_default_clicker = Clicker()
+
+
+def move_to(x: int, y: int) -> None:
+    """Module level convenience wrapper for :class:`Clicker.move`."""
+
+    _default_clicker.move(x, y)
+
+
+def click() -> None:
+    """Module level convenience wrapper for :class:`Clicker.click`."""
+
+    _default_clicker.click()
+
+
+def click_at(x: int, y: int) -> None:
+    """Move to ``(x, y)`` and click using the default :class:`Clicker`."""
+
+    _default_clicker.click_at(x, y)
+

--- a/tests/test_clicker.py
+++ b/tests/test_clicker.py
@@ -1,0 +1,36 @@
+from types import SimpleNamespace
+
+import pytest
+
+from quiz_automation import clicker
+
+
+def test_click_at_uses_pyautogui(monkeypatch):
+    calls = []
+
+    def fake_move(x, y):
+        calls.append(("move", x, y))
+
+    def fake_click():
+        calls.append(("click",))
+
+    monkeypatch.setattr(
+        clicker,
+        "pyautogui",
+        SimpleNamespace(moveTo=fake_move, click=fake_click),
+    )
+
+    clicker.click_at(10, 20)
+
+    assert calls == [("move", 10, 20), ("click",)]
+
+
+def test_missing_pyautogui_attributes_raise(monkeypatch):
+    monkeypatch.setattr(clicker, "pyautogui", object())
+
+    with pytest.raises(RuntimeError):
+        clicker.move_to(0, 0)
+
+    with pytest.raises(RuntimeError):
+        clicker.click()
+


### PR DESCRIPTION
## Summary
- add `Clicker` utilities for mouse movement and clicks with optional `pyautogui` fallback
- provide convenience wrappers for moving and clicking
- cover click logic with unit tests using monkeypatched `pyautogui`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a8e25ac848328ae0eb45d0095d7e3