### PR TITLE
feat: improve chatgpt client configuration and error handling

### DIFF
--- a/quiz_automation/config.py
+++ b/quiz_automation/config.py
@@ -9,6 +9,8 @@ class Settings(BaseSettings):
     """Read configuration from environment variables."""
 
     openai_api_key: str | None = None
+    openai_model: str = "o4-mini-high"
+    openai_system_prompt: str = "Reply with JSON {'answer':'A|B|C|D'}"
     poll_interval: float = 1.0
 
     model_config = SettingsConfigDict(env_prefix="", extra="ignore")

--- a/tests/test_chatgpt_client.py
+++ b/tests/test_chatgpt_client.py
@@ -1,40 +1,88 @@
+import pytest
+
 from quiz_automation import chatgpt_client
 from quiz_automation.chatgpt_client import ChatGPTClient
+from quiz_automation.config import settings
 
 
 class DummyOpenAI:
+    """Minimal stand in for the OpenAI client used in tests."""
+
+    last_kwargs = None
+
     def __init__(self, api_key=None):
         pass
 
     class responses:  # type: ignore
         @staticmethod
         def create(**kwargs):
+            DummyOpenAI.last_kwargs = kwargs
             class R:
-                output_text = ""
+                output_text = '{"answer":"B"}'
             return R()
 
 
+def _setup_client(monkeypatch) -> ChatGPTClient:
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    monkeypatch.setattr(chatgpt_client, "OpenAI", DummyOpenAI)
+    return ChatGPTClient()
+
+
 def test_chatgpt_client_parses_json_response(monkeypatch):
-    monkeypatch.setenv("OPENAI_API_KEY", "x")
-    monkeypatch.setattr(chatgpt_client, "OpenAI", DummyOpenAI)
-    client = ChatGPTClient()
-    monkeypatch.setattr(client, "_completion", lambda prompt: '{"answer":"C"}')
-    assert client.ask("Q?") == "C"
+    client = _setup_client(monkeypatch)
+    assert client.ask("Q?") == "B"
 
 
-def test_chatgpt_client_retries_on_error(monkeypatch):
-    monkeypatch.setenv("OPENAI_API_KEY", "x")
-    monkeypatch.setattr(chatgpt_client, "OpenAI", DummyOpenAI)
-    client = ChatGPTClient()
+def test_chatgpt_client_uses_settings(monkeypatch):
+    monkeypatch.setattr(settings, "openai_model", "my-model")
+    monkeypatch.setattr(settings, "openai_system_prompt", "my prompt")
+    client = _setup_client(monkeypatch)
+    client.ask("Q?")
+    kwargs = DummyOpenAI.last_kwargs
+    assert kwargs["model"] == "my-model"
+    assert kwargs["input"][0]["content"] == "my prompt"
+
+
+def test_chatgpt_client_retries_on_transient_error(monkeypatch):
+    client = _setup_client(monkeypatch)
     calls = {"n": 0}
 
     def fake(prompt: str) -> str:
         calls["n"] += 1
         if calls["n"] < 2:
-            raise ValueError("boom")
+            raise TimeoutError("temporary")
         return '{"answer":"A"}'
 
     monkeypatch.setattr(client, "_completion", fake)
     monkeypatch.setattr("quiz_automation.chatgpt_client.time.sleep", lambda s: None)
     assert client.ask("Q?") == "A"
     assert calls["n"] == 2
+
+
+def test_chatgpt_client_does_not_retry_on_bad_json(monkeypatch):
+    client = _setup_client(monkeypatch)
+    calls = {"n": 0}
+
+    def bad_json(prompt: str) -> str:
+        calls["n"] += 1
+        return "not-json"
+
+    monkeypatch.setattr(client, "_completion", bad_json)
+    with pytest.raises(RuntimeError):
+        client.ask("Q?")
+    assert calls["n"] == 1
+
+
+def test_chatgpt_client_no_retry_on_non_transient_error(monkeypatch):
+    client = _setup_client(monkeypatch)
+    calls = {"n": 0}
+
+    def fatal(prompt: str) -> str:
+        calls["n"] += 1
+        raise ValueError("fatal")
+
+    monkeypatch.setattr(client, "_completion", fatal)
+    with pytest.raises(RuntimeError):
+        client.ask("Q?")
+    assert calls["n"] == 1
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,6 +7,20 @@ def test_config_loads_env(monkeypatch):
     assert cfg.poll_interval == 2.5
 
 
+def test_openai_config_overrides(monkeypatch):
+    monkeypatch.setenv("OPENAI_MODEL", "foo")
+    monkeypatch.setenv("OPENAI_SYSTEM_PROMPT", "prompt")
+    cfg = Settings()
+    assert cfg.openai_model == "foo"
+    assert cfg.openai_system_prompt == "prompt"
+
+
 def test_config_default_poll_interval():
     cfg = Settings()
     assert cfg.poll_interval == 1.0
+
+
+def test_default_openai_values():
+    cfg = Settings()
+    assert cfg.openai_model == "o4-mini-high"
+    assert "answer" in cfg.openai_system_prompt


### PR DESCRIPTION
## Summary
- load OpenAI model and system prompt from Settings
- validate ChatGPT responses with structured JSON schema and limit retries to transient errors
- test config overrides and error paths

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a8e26c55c83288318d6c9ded9a6f5