### PR TITLE
Add Pydantic validation and configurable model

### DIFF
--- a/quiz_automation/config.py
+++ b/quiz_automation/config.py
@@ -9,6 +9,8 @@ class Settings(BaseSettings):
     """Read configuration from environment variables."""
 
     openai_api_key: str | None = None
+    openai_model: str = "o4-mini-high"
+    openai_temperature: float = 0.0
     poll_interval: float = 1.0
 
     model_config = SettingsConfigDict(env_prefix="", extra="ignore")

--- a/tests/test_chatgpt_client.py
+++ b/tests/test_chatgpt_client.py
@@ -1,16 +1,22 @@
+import pytest
+
 from quiz_automation import chatgpt_client
 from quiz_automation.chatgpt_client import ChatGPTClient
 
 
 class DummyOpenAI:
     def __init__(self, api_key=None):
-        pass
+        self.responses = self.Responses()
 
-    class responses:  # type: ignore
-        @staticmethod
-        def create(**kwargs):
+    class Responses:  # type: ignore
+        def __init__(self) -> None:
+            self.last_kwargs: dict | None = None
+
+        def create(self, **kwargs):
+            self.last_kwargs = kwargs
             class R:
                 output_text = ""
+
             return R()
 
 
@@ -38,3 +44,39 @@ def test_chatgpt_client_retries_on_error(monkeypatch):
     monkeypatch.setattr("quiz_automation.chatgpt_client.time.sleep", lambda s: None)
     assert client.ask("Q?") == "A"
     assert calls["n"] == 2
+
+
+def test_chatgpt_client_validation_error(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    monkeypatch.setattr(chatgpt_client, "OpenAI", DummyOpenAI)
+    client = ChatGPTClient()
+    calls = {"n": 0}
+
+    def fake(prompt: str) -> str:
+        calls["n"] += 1
+        return '{"answer":"Z"}'
+
+    monkeypatch.setattr(client, "_completion", fake)
+    with pytest.raises(ValueError):
+        client.ask("Q?")
+    assert calls["n"] == 1
+
+
+def test_chatgpt_client_configurable_parameters(monkeypatch):
+    import importlib
+    from quiz_automation import config
+
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    monkeypatch.setenv("OPENAI_MODEL", "model-env")
+    monkeypatch.setenv("OPENAI_TEMPERATURE", "0.5")
+    importlib.reload(config)
+    monkeypatch.setattr(chatgpt_client, "settings", config.Settings())
+    monkeypatch.setattr(chatgpt_client, "OpenAI", DummyOpenAI)
+
+    client = ChatGPTClient()
+    assert client.model == "model-env"
+    assert client.temperature == 0.5
+
+    client2 = ChatGPTClient(model="model-param", temperature=0.9)
+    assert client2.model == "model-param"
+    assert client2.temperature == 0.9


### PR DESCRIPTION
## Summary
- validate model responses using a pydantic `AnswerResponse` model
- expose model name and temperature via config or ChatGPTClient parameters
- add tests for validation errors and configuration options

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a8e216a588328941fd82efc85c461