### PR TITLE
Handle malformed region selector files

### DIFF
--- a/quiz_automation/logger.py
+++ b/quiz_automation/logger.py
@@ -1,0 +1,24 @@
+import logging
+from datetime import datetime, timezone
+
+
+class TZFormatter(logging.Formatter):
+    """Formatter that uses timezone-aware timestamps."""
+
+    def formatTime(self, record, datefmt=None):  # pragma: no cover - logging internals
+        dt = datetime.fromtimestamp(record.created, tz=timezone.utc)
+        if datefmt:
+            return dt.strftime(datefmt)
+        return dt.isoformat()
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a module-level logger configured for the project."""
+
+    logger = logging.getLogger(name)
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(TZFormatter("%(asctime)s %(levelname)s %(name)s: %(message)s"))
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+    return logger

--- a/tests/test_region_selector.py
+++ b/tests/test_region_selector.py
@@ -12,3 +12,29 @@ def test_region_selector_persistence(tmp_path, monkeypatch):
 
     selector2 = rs_mod.RegionSelector(path)
     assert selector2.load("quiz") == (1, 2, 4, 4)
+
+
+def test_region_selector_list_regions(tmp_path, monkeypatch):
+    path = tmp_path / "coords.json"
+    selector = rs_mod.RegionSelector(path)
+    positions = iter([(1, 2), (5, 6)])
+    monkeypatch.setattr("builtins.input", lambda prompt="": None)
+    monkeypatch.setattr(rs_mod.pyautogui, "position", lambda: next(positions))
+    selector.select("quiz")
+
+    regions = selector.list_regions()
+    assert regions == {"quiz": (1, 2, 4, 4)}
+
+    regions["quiz"] = (0, 0, 0, 0)
+    assert selector.load("quiz") == (1, 2, 4, 4)
+
+
+def test_region_selector_handles_bad_json(tmp_path, caplog):
+    path = tmp_path / "coords.json"
+    path.write_text("{not: valid json}", encoding="utf8")
+
+    with caplog.at_level("WARNING"):
+        selector = rs_mod.RegionSelector(path)
+
+    assert selector.list_regions() == {}
+    assert any("Malformed region file" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- make RegionSelector resilient to bad JSON files
- add list_regions helper for easier debugging
- introduce project logger with timezone-aware formatting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a8e20a900832898cf4249855b7f44