### PR TITLE
Add clicker helper with retries and dry-run

### DIFF
--- a/quiz_automation/automation.py
+++ b/quiz_automation/automation.py
@@ -35,6 +35,7 @@ except Exception:  # pragma: no cover
 
 from .utils import copy_image_to_clipboard, validate_region
 from .stats import Stats
+from .clicker import move_and_click
 
 __all__ = [
     "send_to_chatgpt",
@@ -113,25 +114,31 @@ def read_chatgpt_response(
     raise TimeoutError("No response detected")
 
 
-def click_option(base: Tuple[int, int], index: int, offset: int = 40) -> None:
+def click_option(
+    base: Tuple[int, int], index: int, offset: int = 40, *, retries: int = 3, dry_run: bool = False
+) -> None:
     """Click the answer option at ``index`` using ``base`` as the first option.
 
     ``base`` corresponds to the coordinates of the first option on screen.  The
     function increments the ``y`` coordinate by ``offset`` for each subsequent
     option and performs a mouse click at the calculated position.
 
-    Raises
-    ------
-    RuntimeError
-        If :mod:`pyautogui` is not available.
+    Parameters
+    ----------
+    base:
+        ``(x, y)`` coordinates of the first option.
+    index:
+        Zero-based index of the option to click.
+    offset:
+        Pixel distance between consecutive options.
+    retries:
+        Passed through to :func:`move_and_click`.
+    dry_run:
+        When ``True`` the click is skipped if :mod:`pyautogui` is unavailable.
     """
 
-    if not hasattr(pyautogui, "moveTo"):
-        raise RuntimeError("pyautogui not available")
-
     x, y = base
-    pyautogui.moveTo(x, y + index * offset)
-    pyautogui.click()
+    move_and_click(x, y + index * offset, retries=retries, dry_run=dry_run)
 
 
 def answer_question_via_chatgpt(

--- a/quiz_automation/clicker.py
+++ b/quiz_automation/clicker.py
@@ -1,0 +1,73 @@
+"""High level helpers around optional :mod:`pyautogui` mouse control.
+
+The real project relies on :mod:`pyautogui` which is not available in the
+execution environment for the kata.  This module provides small wrappers that
+gracefully degrade when the dependency is missing.  Consumers can enable a
+``dry_run`` mode to silently skip real mouse interaction while keeping the
+function calls intact for testing purposes.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+try:  # pragma: no cover - optional heavy dependency
+    import pyautogui  # type: ignore
+except Exception:  # pragma: no cover
+    pyautogui = None  # type: ignore
+
+__all__ = ["move_and_click"]
+
+
+def _require_pyautogui(dry_run: bool) -> Any:
+    """Return the :mod:`pyautogui` module or handle absence.
+
+    Parameters
+    ----------
+    dry_run:
+        When ``True`` the function returns ``None`` instead of raising a
+        :class:`RuntimeError` when :mod:`pyautogui` is not importable.
+    """
+
+    if pyautogui is None or not hasattr(pyautogui, "moveTo"):
+        if dry_run:
+            return None
+        raise RuntimeError("pyautogui not available")
+    return pyautogui
+
+
+def move_and_click(
+    x: int,
+    y: int,
+    *,
+    retries: int = 3,
+    delay: float = 0.1,
+    dry_run: bool = False,
+) -> None:
+    """Move the cursor to ``(x, y)`` and perform a click with retries.
+
+    ``pyautogui`` errors are retried ``retries`` times with ``delay`` seconds
+    between attempts.  If the library is missing the function either raises a
+    :class:`RuntimeError` or silently returns when ``dry_run`` is ``True``.
+    """
+
+    pg = _require_pyautogui(dry_run)
+    if pg is None:  # dry run with missing dependency
+        return
+
+    last_exc: Exception | None = None
+    for attempt in range(1, retries + 1):
+        try:
+            pg.moveTo(x, y)
+            pg.click()
+            return
+        except Exception as exc:  # pragma: no cover - hardware errors rare
+            last_exc = exc
+            if attempt >= retries:
+                raise RuntimeError("move_and_click failed") from exc
+            time.sleep(delay)
+
+    if last_exc is not None:  # pragma: no cover - defensive
+        raise RuntimeError("move_and_click failed") from last_exc
+

--- a/tests/test_clicker.py
+++ b/tests/test_clicker.py
@@ -1,0 +1,58 @@
+import types
+
+import pytest
+
+from quiz_automation import clicker
+
+
+def test_move_and_click_dry_run(monkeypatch):
+    """When pyautogui is missing dry_run=True suppresses errors."""
+
+    monkeypatch.setattr(clicker, "pyautogui", None)
+    clicker.move_and_click(10, 10, dry_run=True)  # should not raise
+
+
+def test_move_and_click_missing_pyautogui(monkeypatch):
+    """Missing pyautogui without dry_run should raise RuntimeError."""
+
+    monkeypatch.setattr(clicker, "pyautogui", None)
+    with pytest.raises(RuntimeError):
+        clicker.move_and_click(5, 5)
+
+
+def test_move_and_click_retries_until_success(monkeypatch):
+    """The helper retries failed clicks before succeeding."""
+
+    calls = {"move": 0, "click": 0}
+
+    def move_to(x, y):
+        calls["move"] += 1
+
+    def click():
+        calls["click"] += 1
+        if calls["click"] < 2:
+            raise ValueError("boom")
+
+    fake_pg = types.SimpleNamespace(moveTo=move_to, click=click)
+    monkeypatch.setattr(clicker, "pyautogui", fake_pg)
+
+    clicker.move_and_click(1, 2, retries=3)
+
+    assert calls == {"move": 2, "click": 2}
+
+
+def test_move_and_click_raises_after_retries(monkeypatch):
+    calls = {"click": 0}
+
+    def click():
+        calls["click"] += 1
+        raise ValueError("boom")
+
+    fake_pg = types.SimpleNamespace(moveTo=lambda x, y: None, click=click)
+    monkeypatch.setattr(clicker, "pyautogui", fake_pg)
+
+    with pytest.raises(RuntimeError):
+        clicker.move_and_click(1, 2, retries=2, delay=0)
+
+    assert calls["click"] == 2
+


### PR DESCRIPTION
## Summary
- implement `clicker.move_and_click` wrapper around pyautogui with retries and optional dry-run
- refactor `automation.click_option` to use new clicker helper
- test dry-run and retry/error behaviours for the clicker

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a8e20386483289631b04d1b83d986