### PR TITLE
Add configurable logging and integrate across modules

### DIFF
--- a/quiz_automation/logger.py
+++ b/quiz_automation/logger.py
@@ -1,0 +1,40 @@
+
+"""Simple logging helpers for the quiz automation package."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Final
+
+
+_CONFIGURED: Final[str] = "_quiz_automation_logging_configured"
+
+
+def setup_logging() -> None:
+    """Configure the root logger.
+
+    The log level can be controlled via the ``LOG_LEVEL`` environment
+    variable. If the variable is not set or contains an unknown value, the
+    level defaults to :data:`logging.INFO`.
+    """
+
+    if getattr(logging, _CONFIGURED, False):
+        return
+
+    level_name = os.getenv("LOG_LEVEL", "INFO").upper()
+    level = getattr(logging, level_name, logging.INFO)
+
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+
+    setattr(logging, _CONFIGURED, True)
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a module-level logger with our standard configuration."""
+
+    setup_logging()
+    return logging.getLogger(name)

--- a/quiz_automation/runner.py
+++ b/quiz_automation/runner.py
@@ -10,6 +10,10 @@ from . import automation
 from .automation import answer_question_via_chatgpt
 from .stats import Stats
 from .gui import QuizGUI
+from .logger import get_logger
+
+
+logger = get_logger(__name__)
 
 
 class QuizRunner(threading.Thread):
@@ -39,6 +43,7 @@ class QuizRunner(threading.Thread):
     # The behaviour of this method is tested indirectly via unit tests that
     # patch :func:`answer_question_via_chatgpt`, so it is excluded from coverage
     def run(self) -> None:  # pragma: no cover
+        logger.info("QuizRunner started")
         q: queue.Queue = queue.Queue(maxsize=1)
 
         def capture() -> None:
@@ -65,6 +70,7 @@ class QuizRunner(threading.Thread):
                         stats=self.stats,
                     )
                 except Exception:
+                    logger.exception("Error while answering question")
                     self.stats.record_error()
                 finally:
                     if self.gui is not None:
@@ -76,3 +82,4 @@ class QuizRunner(threading.Thread):
         t_worker.start()
         t_capture.join()
         t_worker.join()
+        logger.info("QuizRunner finished")


### PR DESCRIPTION
## Summary
- implement setup_logging and get_logger utilities with LOG_LEVEL env configuration
- add structured logging to QuizRunner and Watcher threads
- log errors instead of silent failures

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a8e1f895c8328a0321f52838e9aa6