### PR TITLE
Add stop method to QuizRunner

### DIFF
--- a/quiz_automation/runner.py
+++ b/quiz_automation/runner.py
@@ -36,6 +36,10 @@ class QuizRunner(threading.Thread):
         self.stats = stats or Stats()
         self.gui = gui
 
+    def stop(self) -> None:
+        """Signal the runner to stop."""
+        self.stop_flag.set()
+
     # The behaviour of this method is tested indirectly via unit tests that
     # patch :func:`answer_question_via_chatgpt`, so it is excluded from coverage
     def run(self) -> None:  # pragma: no cover

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -35,7 +35,7 @@ def test_runner_triggers_full_flow(monkeypatch):
 
     def wrapped(*args, **kwargs):
         result = orig(*args, **kwargs)
-        runner.stop_flag.set()
+        runner.stop()
         return result
 
     monkeypatch.setattr(automation, "answer_question_via_chatgpt", wrapped)

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -31,7 +31,7 @@ def test_watcher_emits_event(monkeypatch):
     monkeypatch.setattr(w, "is_new_question", lambda text: True)
 
     def fake_sleep(_):
-        w.stop_flag.set()
+        w.stop()
 
     monkeypatch.setattr("quiz_automation.watcher.time.sleep", fake_sleep)
     w.run()


### PR DESCRIPTION
## Summary
- Add `stop` method to `QuizRunner` to expose a public way to halt the thread
- Update tests to use `runner.stop()` and `Watcher.stop()` instead of manipulating stop flags directly
## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a8e1c4aac832896f383a46213979e