### PR TITLE
Add CLI with GUI/headless modes and console entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Basic AI Auto Assistant
+
+Utilities for automating multiple choice quizzes.
+
+## Command line usage
+
+After installation the project exposes a `quiz-automation` command.
+
+```bash
+# Start with a small stats window
+quiz-automation --mode gui
+
+# Run without any GUI components
+quiz-automation --mode headless
+```
+
+The same interface is available by executing the script directly:
+
+```bash
+python run.py --mode gui
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "basic-ai-auto-assistant"
+version = "0.1.0"
+description = "A lightweight quiz automation assistant."
+requires-python = ">=3.10"
+
+[project.scripts]
+quiz-automation = "run:main"

--- a/run.py
+++ b/run.py
@@ -1,12 +1,37 @@
-"""Entry point for running the quiz automation GUI."""
+"""Command-line interface for quiz automation."""
 from __future__ import annotations
+
+import argparse
 
 from quiz_automation.gui import QuizGUI
 
 
-def main() -> None:
-    gui = QuizGUI()
-    gui.run()
+def main(argv: list[str] | None = None) -> None:
+    """Run the quiz automation tool.
+
+    Parameters
+    ----------
+    argv:
+        Optional list of command line arguments for testing purposes.
+    """
+    parser = argparse.ArgumentParser(description="Quiz automation entry point")
+    parser.add_argument(
+        "--mode",
+        choices=["gui", "headless"],
+        default="gui",
+        help="Choose whether to launch the GUI or run in headless mode.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.mode == "gui":
+        gui = QuizGUI()
+        app = getattr(gui, "_app", None)
+        if app is not None:
+            app.exec()
+        else:
+            print("PySide6 is not available; running without GUI.")
+    else:
+        print("Running in headless mode. GUI will not be launched.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- replace run.py with an argparse-driven CLI supporting GUI or headless operation
- add pyproject.toml exposing `quiz-automation` console entry point
- document CLI usage in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a8e1798088328a103e8f98b9e4024