### PR TITLE
feat: configurable model and explicit OpenAI error handling

### DIFF
--- a/quiz_automation/chatgpt_client.py
+++ b/quiz_automation/chatgpt_client.py
@@ -3,27 +3,43 @@ from __future__ import annotations
 
 import json
 import time
+import logging
 from typing import Optional
 
 try:  # pragma: no cover - optional dependency
-    from openai import OpenAI
-except Exception:  # pragma: no cover
+    from openai import (
+        OpenAI,
+        APIError,
+        APIConnectionError,
+        RateLimitError,
+        APITimeoutError,
+    )
+except ModuleNotFoundError:  # pragma: no cover
     OpenAI = None  # type: ignore
+    APIError = APIConnectionError = RateLimitError = APITimeoutError = Exception  # type: ignore
 
 from .config import settings
+
+
+logger = logging.getLogger(__name__)
 
 
 class ChatGPTClient:
     """Wrapper around the OpenAI SDK that returns a single-letter answer."""
 
-    def __init__(self, api_key: Optional[str] = None) -> None:
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        model: Optional[str] = None,
+    ) -> None:
         if OpenAI is None:  # pragma: no cover
             raise RuntimeError("openai package not available")
         self.client = OpenAI(api_key=api_key or settings.openai_api_key)
+        self.model = model or settings.openai_model
 
     def _completion(self, prompt: str) -> str:
         response = self.client.responses.create(
-            model="o4-mini-high",
+            model=self.model,
             input=[
                 {"role": "system", "content": "Reply with JSON {'answer':'A|B|C|D'}"},
                 {"role": "user", "content": prompt},
@@ -38,6 +54,14 @@ class ChatGPTClient:
                 raw = self._completion(prompt)
                 data = json.loads(raw)
                 return data["answer"]
-            except Exception:
+            except (
+                APIError,
+                APIConnectionError,
+                RateLimitError,
+                APITimeoutError,
+                json.JSONDecodeError,
+            ) as exc:
+                logger.warning("Attempt %d/%d failed: %s", attempt + 1, retries, exc)
                 time.sleep(2**attempt)
+        logger.error("All %d attempts failed", retries)
         raise RuntimeError("Failed to get model response")

--- a/quiz_automation/config.py
+++ b/quiz_automation/config.py
@@ -9,6 +9,7 @@ class Settings(BaseSettings):
     """Read configuration from environment variables."""
 
     openai_api_key: str | None = None
+    openai_model: str = "o4-mini-high"
     poll_interval: float = 1.0
 
     model_config = SettingsConfigDict(env_prefix="", extra="ignore")

--- a/tests/test_chatgpt_client.py
+++ b/tests/test_chatgpt_client.py
@@ -1,3 +1,5 @@
+import pytest
+
 from quiz_automation import chatgpt_client
 from quiz_automation.chatgpt_client import ChatGPTClient
 
@@ -22,19 +24,73 @@ def test_chatgpt_client_parses_json_response(monkeypatch):
     assert client.ask("Q?") == "C"
 
 
-def test_chatgpt_client_retries_on_error(monkeypatch):
+def test_chatgpt_client_retries_on_api_error(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "x")
     monkeypatch.setattr(chatgpt_client, "OpenAI", DummyOpenAI)
+
+    class APIError(Exception):
+        pass
+
+    monkeypatch.setattr(chatgpt_client, "APIError", APIError)
+
     client = ChatGPTClient()
     calls = {"n": 0}
 
     def fake(prompt: str) -> str:
         calls["n"] += 1
         if calls["n"] < 2:
-            raise ValueError("boom")
+            raise APIError("boom")
         return '{"answer":"A"}'
 
     monkeypatch.setattr(client, "_completion", fake)
     monkeypatch.setattr("quiz_automation.chatgpt_client.time.sleep", lambda s: None)
     assert client.ask("Q?") == "A"
     assert calls["n"] == 2
+
+
+def test_chatgpt_client_allows_custom_model(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+
+    class ModelOpenAI:
+        def __init__(self, api_key=None):
+            pass
+
+        class responses:  # type: ignore
+            called = {}
+
+            @staticmethod
+            def create(**kwargs):
+                ModelOpenAI.responses.called = kwargs
+                class R:
+                    output_text = '{"answer":"B"}'
+                return R()
+
+    monkeypatch.setattr(chatgpt_client, "OpenAI", ModelOpenAI)
+    client = ChatGPTClient(model="gpt-test")
+    assert client.ask("Q?") == "B"
+    assert ModelOpenAI.responses.called["model"] == "gpt-test"
+
+
+def test_chatgpt_client_logs_and_raises_after_retries(monkeypatch, caplog):
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    monkeypatch.setattr(chatgpt_client, "OpenAI", DummyOpenAI)
+
+    class APIError(Exception):
+        pass
+
+    monkeypatch.setattr(chatgpt_client, "APIError", APIError)
+
+    client = ChatGPTClient()
+
+    def boom(prompt: str) -> str:
+        raise APIError("fail")
+
+    monkeypatch.setattr(client, "_completion", boom)
+    monkeypatch.setattr("quiz_automation.chatgpt_client.time.sleep", lambda s: None)
+
+    with caplog.at_level("WARNING"):
+        with pytest.raises(RuntimeError):
+            client.ask("Q?", retries=2)
+
+    assert "Attempt 1/2 failed" in caplog.text
+    assert "All 2 attempts failed" in caplog.text


### PR DESCRIPTION
## Summary
- allow selecting OpenAI model via settings or constructor
- handle specific OpenAI SDK exceptions instead of blanket `Exception`
- log retry attempts and final failure with logging
- add tests for custom model selection and API error handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a8e17386c8328bb68b01e38430c6a