### PR TITLE
Parse quiz answer letter with regex and add tests

### DIFF
--- a/quiz_automation/automation.py
+++ b/quiz_automation/automation.py
@@ -157,14 +157,17 @@ def answer_question_via_chatgpt(
     start = time.time()
     send_to_chatgpt(quiz_image, chatgpt_box)
     response = read_chatgpt_response(response_region)
+    match = re.search(r"\b([A-D])\b", response, re.IGNORECASE)
+    letter = match.group(1).upper() if match else "A"
 
-    
     try:
         idx = options.index(letter)
     except ValueError:
         # Fall back to alphabetical ordering; ensures a valid index even if the
         # model returns an unexpected string such as "E".
         idx = max(0, ord(letter) - ord("A"))
+
+    logger.info("ChatGPT chose %s", letter)
 
     click_option(option_base, idx)
 

--- a/quiz_automation/chatgpt_client.py
+++ b/quiz_automation/chatgpt_client.py
@@ -34,7 +34,7 @@ class ChatGPTClient:
 
     def _completion(self, prompt: str) -> str:
         response = self.client.responses.create(
-
+            model=settings.openai_model,
             input=[
                 {"role": "system", "content": settings.openai_system_prompt},
                 {"role": "user", "content": prompt},

--- a/tests/test_automation.py
+++ b/tests/test_automation.py
@@ -1,4 +1,52 @@
 
 
+"""Tests for :mod:`quiz_automation.automation`."""
+
 from quiz_automation import automation
+
+
+def test_extracts_letter_and_clicks_correct_index(monkeypatch):
+    monkeypatch.setattr(automation, "send_to_chatgpt", lambda img, box: None)
+    monkeypatch.setattr(
+        automation,
+        "read_chatgpt_response",
+        lambda region, timeout=20.0: "The answer is c)",
+    )
+
+    captured = {}
+
+    def fake_click(base, idx, offset=40):
+        captured["idx"] = idx
+
+    monkeypatch.setattr(automation, "click_option", fake_click)
+
+    letter = automation.answer_question_via_chatgpt(
+        "img", (0, 0), (0, 0, 10, 10), ["A", "B", "C", "D"], (0, 0)
+    )
+
+    assert letter == "C"
+    assert captured["idx"] == 2
+
+
+def test_falls_back_to_alphabetical_index(monkeypatch):
+    monkeypatch.setattr(automation, "send_to_chatgpt", lambda img, box: None)
+    monkeypatch.setattr(
+        automation,
+        "read_chatgpt_response",
+        lambda region, timeout=20.0: "Answer D",
+    )
+
+    captured = {}
+
+    def fake_click(base, idx, offset=40):
+        captured["idx"] = idx
+
+    monkeypatch.setattr(automation, "click_option", fake_click)
+
+    letter = automation.answer_question_via_chatgpt(
+        "img", (0, 0), (0, 0, 10, 10), ["A", "B", "C"], (0, 0)
+    )
+
+    assert letter == "D"
+    assert captured["idx"] == 3
 


### PR DESCRIPTION
## Summary
- Extract first A–D letter from ChatGPT responses using regex, normalize it and log the choice
- Add fallback index computation and tests for parsing and fallback
- Ensure ChatGPT client passes configured model to OpenAI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ad3e4b9648328ad38f31edf946e23