### PR TITLE
Add tests for clicker and automation helpers

### DIFF
--- a/quiz_automation/automation.py
+++ b/quiz_automation/automation.py
@@ -157,8 +157,9 @@ def answer_question_via_chatgpt(
     start = time.time()
     send_to_chatgpt(quiz_image, chatgpt_box)
     response = read_chatgpt_response(response_region)
+    matches = re.findall(r"[A-D]", response.upper())
+    letter = matches[-1] if matches else ""
 
-    
     try:
         idx = options.index(letter)
     except ValueError:
@@ -167,6 +168,7 @@ def answer_question_via_chatgpt(
         idx = max(0, ord(letter) - ord("A"))
 
     click_option(option_base, idx)
+    logger.info("ChatGPT chose %s", letter)
 
     if stats is not None:
         duration = time.time() - start

--- a/quiz_automation/chatgpt_client.py
+++ b/quiz_automation/chatgpt_client.py
@@ -34,7 +34,7 @@ class ChatGPTClient:
 
     def _completion(self, prompt: str) -> str:
         response = self.client.responses.create(
-
+            model=settings.openai_model,
             input=[
                 {"role": "system", "content": settings.openai_system_prompt},
                 {"role": "user", "content": prompt},

--- a/quiz_automation/clicker.py
+++ b/quiz_automation/clicker.py
@@ -1,6 +1,72 @@
+"""Lightweight helpers for moving the mouse and performing clicks.
 
+The real project uses :mod:`pyautogui` for desktop automation.  The tests in
+this kata run in a minimal environment where that dependency may be missing, so
+this module mirrors the graceful fallback approach used elsewhere in the
+project.  When :mod:`pyautogui` cannot be imported a very small stand‑in object
+provides the attributes used here which allows the functions to be imported and
+monkeypatched for unit tests.
 """
 
 from __future__ import annotations
 
-<
+try:  # pragma: no cover - optional heavy dependency
+    import pyautogui  # type: ignore
+except Exception:  # pragma: no cover
+    # ``pyautogui`` is not available.  Provide a minimal mock so the rest of the
+    # code can still be exercised.  Each attribute mirrors the functions used in
+    # this module and can be monkeypatched in tests if required.
+    from types import SimpleNamespace
+
+    pyautogui = SimpleNamespace(  # type: ignore[attr-defined]
+        moveTo=lambda *_, **__: None,
+        click=lambda *_, **__: None,
+    )
+
+__all__ = ["Clicker", "move_to", "click", "click_at"]
+
+
+class Clicker:
+    """Encapsulate mouse movement and clicking via :mod:`pyautogui`."""
+
+    def move(self, x: int, y: int) -> None:
+        """Move the mouse cursor to ``(x, y)``."""
+
+        if not hasattr(pyautogui, "moveTo"):
+            raise RuntimeError("pyautogui not available")
+        pyautogui.moveTo(x, y)
+
+    def click(self) -> None:
+        """Perform a mouse click at the current cursor location."""
+
+        if not hasattr(pyautogui, "click"):
+            raise RuntimeError("pyautogui not available")
+        pyautogui.click()
+
+    def click_at(self, x: int, y: int) -> None:
+        """Move the mouse to ``(x, y)`` and click."""
+
+        self.move(x, y)
+        self.click()
+
+
+_default_clicker = Clicker()
+
+
+def move_to(x: int, y: int) -> None:
+    """Module level convenience wrapper for :class:`Clicker.move`."""
+
+    _default_clicker.move(x, y)
+
+
+def click() -> None:
+    """Module level convenience wrapper for :class:`Clicker.click`."""
+
+    _default_clicker.click()
+
+
+def click_at(x: int, y: int) -> None:
+    """Move to ``(x, y)`` and click using the default :class:`Clicker`."""
+
+    _default_clicker.click_at(x, y)
+

--- a/tests/test_automation.py
+++ b/tests/test_automation.py
@@ -1,4 +1,89 @@
-
+import types
+import pytest
 
 from quiz_automation import automation
+
+
+def test_send_to_chatgpt_success(monkeypatch):
+    """Image is copied and pasted at given coordinates."""
+
+    calls = []
+
+    def fake_copy(img):
+        calls.append(("copy", img))
+        return True
+
+    def move(x, y):
+        calls.append(("move", x, y))
+
+    def hotkey(*keys):
+        calls.append(("hotkey", keys))
+
+    fake = types.SimpleNamespace(moveTo=move, hotkey=hotkey)
+    monkeypatch.setattr(automation, "pyautogui", fake)
+    monkeypatch.setattr(automation, "copy_image_to_clipboard", fake_copy)
+
+    automation.send_to_chatgpt("img", (1, 2))
+
+    assert calls == [("copy", "img"), ("move", 1, 2), ("hotkey", ("ctrl", "v"))]
+
+
+def test_send_to_chatgpt_copy_failure(monkeypatch):
+    """If the image cannot be copied a ``RuntimeError`` is raised."""
+
+    monkeypatch.setattr(automation, "pyautogui", types.SimpleNamespace(moveTo=lambda *a, **k: None, hotkey=lambda *a, **k: None))
+    monkeypatch.setattr(automation, "copy_image_to_clipboard", lambda img: False)
+
+    with pytest.raises(RuntimeError):
+        automation.send_to_chatgpt("img", (0, 0))
+
+
+def test_read_chatgpt_response_success(monkeypatch):
+    """Return OCR text once non-empty."""
+
+    monkeypatch.setattr(automation, "pyautogui", types.SimpleNamespace(screenshot=lambda region: "img"))
+    monkeypatch.setattr(automation, "pytesseract", types.SimpleNamespace(image_to_string=lambda img: " hello "))
+    monkeypatch.setattr(automation, "validate_region", lambda region: None)
+
+    text = automation.read_chatgpt_response((0, 0, 1, 1), timeout=0.1)
+    assert text == "hello"
+
+
+def test_read_chatgpt_response_timeout(monkeypatch):
+    """If no text appears before timeout a ``TimeoutError`` is raised."""
+
+    monkeypatch.setattr(automation, "pyautogui", types.SimpleNamespace(screenshot=lambda region: "img"))
+    monkeypatch.setattr(automation, "pytesseract", types.SimpleNamespace(image_to_string=lambda img: ""))
+    monkeypatch.setattr(automation, "validate_region", lambda region: None)
+    monkeypatch.setattr(automation, "time", types.SimpleNamespace(time=iter([0, 0.6, 1.2]).__next__, sleep=lambda _: None))
+
+    with pytest.raises(TimeoutError):
+        automation.read_chatgpt_response((0, 0, 1, 1), timeout=1.0)
+
+
+def test_click_option_moves_and_clicks(monkeypatch):
+    """``click_option`` computes the y-offset correctly and clicks."""
+
+    calls = []
+
+    def move(x, y):
+        calls.append(("move", x, y))
+
+    def do_click():
+        calls.append(("click",))
+
+    fake = types.SimpleNamespace(moveTo=move, click=do_click)
+    monkeypatch.setattr(automation, "pyautogui", fake)
+
+    automation.click_option((10, 10), 2, offset=5)
+
+    assert calls == [("move", 10, 20), ("click",)]
+
+
+def test_click_option_missing_pyautogui(monkeypatch):
+    """If ``pyautogui`` lacks ``moveTo`` a ``RuntimeError`` is raised."""
+
+    monkeypatch.setattr(automation, "pyautogui", object())
+    with pytest.raises(RuntimeError):
+        automation.click_option((0, 0), 0)
 

--- a/tests/test_clicker.py
+++ b/tests/test_clicker.py
@@ -1,0 +1,40 @@
+import types
+import pytest
+
+from quiz_automation import clicker
+
+
+def test_click_at_moves_and_clicks(monkeypatch):
+    """``Clicker.click_at`` should move to the coordinates then click."""
+
+    calls: list[tuple] = []
+
+    def move_to(x, y):
+        calls.append(("move", x, y))
+
+    def do_click():
+        calls.append(("click",))
+
+    fake = types.SimpleNamespace(moveTo=move_to, click=do_click)
+    monkeypatch.setattr(clicker, "pyautogui", fake)
+
+    clicker.Clicker().click_at(10, 20)
+
+    assert calls == [("move", 10, 20), ("click",)]
+
+
+def test_move_raises_when_pyautogui_missing(monkeypatch):
+    """``Clicker.move`` should raise when ``pyautogui`` lacks ``moveTo``."""
+
+    monkeypatch.setattr(clicker, "pyautogui", object())
+    with pytest.raises(RuntimeError):
+        clicker.Clicker().move(1, 2)
+
+
+def test_click_raises_when_pyautogui_missing(monkeypatch):
+    """``Clicker.click`` should raise when ``pyautogui`` lacks ``click``."""
+
+    monkeypatch.setattr(clicker, "pyautogui", types.SimpleNamespace(moveTo=lambda *a, **k: None))
+    with pytest.raises(RuntimeError):
+        clicker.Clicker().click()
+


### PR DESCRIPTION
## Summary
- test Clicker coordinate math and error handling
- verify send_to_chatgpt, read_chatgpt_response and click_option success/failure flows
- fix automation helpers and ChatGPT client to satisfy tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ad3e721288328ae1b277d531923ea