### PR TITLE
Add packaging metadata and CLI entry script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,25 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "basic-ai-auto-assistant"
 version = "0.1.0"
+description = "Automates multiple-choice quizzes via ChatGPT with optional desktop GUI and OCR tools."
+dependencies = [
+    "pydantic",
+    "pydantic-settings",
+    "mss",
+]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Intended Audience :: Developers",
+    "Operating System :: OS Independent",
+]
+
+[project.optional-dependencies]
+full = [
+    "pyautogui",
+    "pytesseract",
+    "PySide6",
+    "opencv-python",
+]
+
+[project.scripts]
+quiz-automation = "quiz_automation.run:main"

--- a/quiz_automation/run.py
+++ b/quiz_automation/run.py
@@ -1,0 +1,38 @@
+"""Command-line interface for quiz automation."""
+from __future__ import annotations
+
+import argparse
+
+from quiz_automation.gui import QuizGUI
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Run the quiz automation tool.
+
+    Parameters
+    ----------
+    argv:
+        Optional list of command line arguments for testing purposes.
+    """
+    parser = argparse.ArgumentParser(description="Quiz automation entry point")
+    parser.add_argument(
+        "--mode",
+        choices=["gui", "headless"],
+        default="gui",
+        help="Choose whether to launch the GUI or run in headless mode.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.mode == "gui":
+        gui = QuizGUI()
+        app = getattr(gui, "_app", None)
+        if app is not None:
+            app.exec()
+        else:
+            print("PySide6 is not available; running without GUI.")
+    else:
+        print("Running in headless mode. GUI will not be launched.")
+
+
+if __name__ == "__main__":
+    main()

--- a/run.py
+++ b/run.py
@@ -1,38 +1,4 @@
-"""Command-line interface for quiz automation."""
-from __future__ import annotations
-
-import argparse
-
-from quiz_automation.gui import QuizGUI
-
-
-def main(argv: list[str] | None = None) -> None:
-    """Run the quiz automation tool.
-
-    Parameters
-    ----------
-    argv:
-        Optional list of command line arguments for testing purposes.
-    """
-    parser = argparse.ArgumentParser(description="Quiz automation entry point")
-    parser.add_argument(
-        "--mode",
-        choices=["gui", "headless"],
-        default="gui",
-        help="Choose whether to launch the GUI or run in headless mode.",
-    )
-    args = parser.parse_args(argv)
-
-    if args.mode == "gui":
-        gui = QuizGUI()
-        app = getattr(gui, "_app", None)
-        if app is not None:
-            app.exec()
-        else:
-            print("PySide6 is not available; running without GUI.")
-    else:
-        print("Running in headless mode. GUI will not be launched.")
-
+from quiz_automation.run import main
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- add core and optional dependencies to pyproject
- provide CLI entrypoint `quiz-automation`
- move command-line runner into `quiz_automation.run`

## Testing
- `pytest` *(fails: KeyError 'model'; NameError 'letter'; AssertionError in runner flow; watcher pause/resume)*

------
https://chatgpt.com/codex/tasks/task_e_689ad3e925a8832886c4ede867f68faf