### PR TITLE
feat: expose top-level API

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ The requirements file installs everything needed to run the full automation.  Fo
 
 ## CLI example
 ```python
-from quiz_automation.automation import answer_question_via_chatgpt
-from quiz_automation.stats import Stats
+from quiz_automation import answer_question_via_chatgpt, Stats
 import pyautogui
 
 quiz_region = (100, 100, 600, 400)
@@ -42,8 +41,7 @@ This snippet grabs the current question, asks ChatGPT for help, and clicks the s
 
 ## GUI example
 ```python
-from quiz_automation.gui import QuizGUI
-from quiz_automation.runner import QuizRunner
+from quiz_automation import QuizGUI, QuizRunner
 
 quiz_region = (100, 100, 600, 400)
 chatgpt_box = (800, 900)

--- a/quiz_automation/__init__.py
+++ b/quiz_automation/__init__.py
@@ -1,0 +1,28 @@
+"""Convenient top-level imports for the quiz_automation package.
+
+This module re-exports the most commonly used classes and helper functions so
+that examples can simply import from :mod:`quiz_automation` without needing to
+know the internal module layout.  Only a small and well-defined public surface
+area is provided here.
+"""
+
+from .automation import (
+    answer_question_via_chatgpt,
+    click_option,
+    read_chatgpt_response,
+    send_to_chatgpt,
+)
+from .gui import QuizGUI
+from .runner import QuizRunner
+from .stats import Stats
+
+__all__ = [
+    "QuizRunner",
+    "QuizGUI",
+    "answer_question_via_chatgpt",
+    "send_to_chatgpt",
+    "read_chatgpt_response",
+    "click_option",
+    "Stats",
+]
+

--- a/run.py
+++ b/run.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import argparse
 
-from quiz_automation.gui import QuizGUI
+from quiz_automation import QuizGUI
 
 
 def main(argv: list[str] | None = None) -> None:


### PR DESCRIPTION
## Summary
- re-export core helpers like `QuizRunner`, `QuizGUI`, and `answer_question_via_chatgpt` at package root for simpler imports
- document and script examples now use the simplified package-level imports

## Testing
- `pytest` *(fails: KeyError: 'model', NameError: name 'letter' is not defined, assertion failures, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689ad3eb28988328954bfa3debc84d23