### PR TITLE
Run headless quiz runner

### DIFF
--- a/run.py
+++ b/run.py
@@ -2,8 +2,25 @@
 from __future__ import annotations
 
 import argparse
+import os
+from typing import Tuple
 
 from quiz_automation import QuizGUI
+from quiz_automation.runner import QuizRunner
+
+
+def _parse_tuple(env_name: str, default: Tuple[int, ...]) -> Tuple[int, ...]:
+    """Parse a comma-separated tuple from an environment variable."""
+
+    raw = os.getenv(env_name)
+    if raw:
+        try:
+            parts = tuple(int(p.strip()) for p in raw.split(","))
+            if len(parts) == len(default):
+                return parts
+        except ValueError:
+            pass
+    return default
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -31,7 +48,13 @@ def main(argv: list[str] | None = None) -> None:
         else:
             print("PySide6 is not available; running without GUI.")
     else:
-        print("Running in headless mode. GUI will not be launched.")
+        quiz_region = _parse_tuple("QUIZ_REGION", (100, 100, 600, 400))
+        chat_box = _parse_tuple("CHAT_BOX", (800, 900))
+        response_region = _parse_tuple("RESPONSE_REGION", (100, 550, 600, 150))
+        option_base = _parse_tuple("OPTION_BASE", (100, 520))
+        options = list("ABCD")
+        runner = QuizRunner(quiz_region, chat_box, response_region, options, option_base)
+        runner.start()
 
 
 if __name__ == "__main__":

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,0 +1,15 @@
+from unittest.mock import MagicMock
+
+import run
+
+
+def test_headless_invokes_quiz_runner(monkeypatch):
+    instance = MagicMock()
+    mock_runner = MagicMock(return_value=instance)
+    monkeypatch.setattr(run, "QuizRunner", mock_runner)
+
+    run.main(["--mode", "headless"])
+
+    mock_runner.assert_called_once()
+    instance.start.assert_called_once_with()
+


### PR DESCRIPTION
## Summary
- parse screen regions from environment vars or defaults
- start QuizRunner in headless mode
- test CLI headless mode

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689aedb5f1e88328afe19f3e6f6bee10