### PR TITLE
Add dependency metadata and CLI entry point

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,23 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "basic-ai-auto-assistant"
 version = "0.1.0"
+description = "Automation helpers for multiple-choice quizzes."
+classifiers = [
+    "Programming Language :: Python :: 3",
+]
+dependencies = [
+    "pydantic",
+    "pydantic-settings",
+    "mss",
+]
+
+[project.optional-dependencies]
+full = [
+    "pyautogui",
+    "pytesseract",
+    "opencv-python",
+    "PySide6",
+]
+
+[project.scripts]
+quiz-automation = "run:main"


### PR DESCRIPTION
## Summary
- declare required runtime dependencies
- define optional extras for desktop automation
- expose `quiz-automation` CLI entry point

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689aedb6c7348328a2b572cb7c4bf574