### PR TITLE
Refactor option clicking to use Clicker class

### DIFF
--- a/quiz_automation/automation.py
+++ b/quiz_automation/automation.py
@@ -37,6 +37,7 @@ except Exception:  # pragma: no cover
 from .utils import copy_image_to_clipboard, validate_region
 from .stats import Stats
 from .logger import get_logger
+from .clicker import Clicker
 
 logger = get_logger(__name__)
 
@@ -123,7 +124,8 @@ def click_option(base: Tuple[int, int], index: int, offset: int = 40) -> None:
 
     ``base`` corresponds to the coordinates of the first option on screen.  The
     function increments the ``y`` coordinate by ``offset`` for each subsequent
-    option and performs a mouse click at the calculated position.
+    option and performs a mouse click at the calculated position via
+    :class:`~quiz_automation.clicker.Clicker`.
 
     Raises
     ------
@@ -131,12 +133,7 @@ def click_option(base: Tuple[int, int], index: int, offset: int = 40) -> None:
         If :mod:`pyautogui` is not available.
     """
 
-    if not hasattr(pyautogui, "moveTo"):
-        raise RuntimeError("pyautogui not available")
-
-    x, y = base
-    pyautogui.moveTo(x, y + index * offset)
-    pyautogui.click()
+    Clicker(base, offset).click_option(index)
 
 
 def answer_question_via_chatgpt(

--- a/quiz_automation/clicker.py
+++ b/quiz_automation/clicker.py
@@ -29,6 +29,20 @@ __all__ = ["Clicker", "move_to", "click", "click_at"]
 class Clicker:
     """Encapsulate mouse movement and clicking via :mod:`pyautogui`."""
 
+    def __init__(self, base: tuple[int, int] = (0, 0), offset: int = 40) -> None:
+        """Initialize the clicker with ``base`` coordinates and ``offset``.
+
+        Parameters
+        ----------
+        base:
+            Screen coordinates of the first option.  Defaults to ``(0, 0)``.
+        offset:
+            Vertical distance in pixels between successive options.
+        """
+
+        self.base = base
+        self.offset = offset
+
     def move(self, x: int, y: int) -> None:
         """Move the mouse cursor to ``(x, y)``."""
 
@@ -48,6 +62,12 @@ class Clicker:
 
         self.move(x, y)
         self.click()
+
+    def click_option(self, index: int) -> None:
+        """Click the option at ``index`` relative to ``base`` and ``offset``."""
+
+        x, y = self.base
+        self.click_at(x, y + index * self.offset)
 
 
 _default_clicker = Clicker()

--- a/tests/test_clicker.py
+++ b/tests/test_clicker.py
@@ -23,6 +23,25 @@ def test_click_at_moves_and_clicks(monkeypatch):
     assert calls == [("move", 10, 20), ("click",)]
 
 
+def test_click_option_uses_base_and_offset(monkeypatch):
+    """``Clicker.click_option`` should apply ``base`` and ``offset``."""
+
+    calls: list[tuple] = []
+
+    def move_to(x, y):
+        calls.append(("move", x, y))
+
+    def do_click():
+        calls.append(("click",))
+
+    fake = types.SimpleNamespace(moveTo=move_to, click=do_click)
+    monkeypatch.setattr(clicker, "pyautogui", fake)
+
+    clicker.Clicker((10, 10), offset=5).click_option(2)
+
+    assert calls == [("move", 10, 20), ("click",)]
+
+
 def test_move_raises_when_pyautogui_missing(monkeypatch):
     """``Clicker.move`` should raise when ``pyautogui`` lacks ``moveTo``."""
 


### PR DESCRIPTION
## Summary
- extend `Clicker` with base coordinates and offset
- add `click_option` method to `Clicker`
- reimplement `automation.click_option` to delegate to `Clicker`
- update tests for new Clicker API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689aedb759dc8328b2334d65bf5a18b1