### PR TITLE
Join QuizRunner thread and handle keyboard interrupts

### DIFF
--- a/run.py
+++ b/run.py
@@ -54,7 +54,12 @@ def main(argv: list[str] | None = None) -> None:
         option_base = _parse_tuple("OPTION_BASE", (100, 520))
         options = list("ABCD")
         runner = QuizRunner(quiz_region, chat_box, response_region, options, option_base)
-        runner.start()
+        try:
+            runner.start()
+            runner.join()
+        except KeyboardInterrupt:
+            runner.stop()
+            runner.join()
 
 
 if __name__ == "__main__":

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -12,4 +12,19 @@ def test_headless_invokes_quiz_runner(monkeypatch):
 
     mock_runner.assert_called_once()
     instance.start.assert_called_once_with()
+    instance.join.assert_called_once_with()
+
+
+def test_headless_handles_keyboard_interrupt(monkeypatch):
+    instance = MagicMock()
+    instance.join.side_effect = [KeyboardInterrupt, None]
+    mock_runner = MagicMock(return_value=instance)
+    monkeypatch.setattr(run, "QuizRunner", mock_runner)
+
+    run.main(["--mode", "headless"])
+
+    mock_runner.assert_called_once()
+    instance.start.assert_called_once_with()
+    assert instance.join.call_count == 2
+    instance.stop.assert_called_once_with()
 


### PR DESCRIPTION
## Summary
- Block the main thread by joining `QuizRunner` and gracefully handle `KeyboardInterrupt` by stopping the runner
- Test that `QuizRunner.join` is invoked and that `KeyboardInterrupt` triggers `stop`

## Testing
- `pytest tests/test_run.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689afb3ccc448328bbe652ec91873a43