### PR TITLE
refactor: simplify Stats lock initialization

### DIFF
--- a/quiz_automation/stats.py
+++ b/quiz_automation/stats.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from threading import Lock
 from typing import List
-import threading
 
 
 @dataclass
@@ -23,9 +22,6 @@ class Stats:
     questions_answered: int = 0
     errors: int = 0
     _lock: Lock = field(default_factory=Lock, init=False, repr=False)
-
-    def __post_init__(self) -> None:
-        self._lock = threading.Lock()
 
     def record(self, duration: float, tokens: int) -> None:
         """Record timing and token usage for a successful question."""


### PR DESCRIPTION
## Summary
- remove redundant `__post_init__` and `threading` import from `Stats`
- rely on dataclass `default_factory` for lock initialization

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689afb3e78a8832886adf99dfbae987f