### PR TITLE
refactor: centralize screen region settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ The package installs a `quiz-automation` script that wraps the command‑line in
 ### Environment variables
 Set `OPENAI_API_KEY` for access to the OpenAI API.  Additional settings read by the tool include `OPENAI_MODEL`, `OPENAI_SYSTEM_PROMPT`, `POLL_INTERVAL`, `MODEL_NAME`, and `TEMPERATURE`.
 
+Screen regions can be customized with `QUIZ_REGION`, `CHAT_BOX`, `RESPONSE_REGION`, and `OPTION_BASE`. Each is a JSON array of integers such as `QUIZ_REGION=[100,100,600,400]`.
+
 An example `.env` file:
 
 ```dotenv
@@ -37,6 +39,10 @@ OPENAI_MODEL=o4-mini-high
 # POLL_INTERVAL=1.0
 # MODEL_NAME=o4-mini-high
 # TEMPERATURE=0.0
+# QUIZ_REGION=[100,100,600,400]
+# CHAT_BOX=[800,900]
+# RESPONSE_REGION=[100,550,600,150]
+# OPTION_BASE=[100,520]
 ```
 
 ### Optional dependencies
@@ -61,16 +67,21 @@ quiz-automation --mode gui
 ## CLI example
 ```python
 from quiz_automation import answer_question_via_chatgpt, Stats
+from quiz_automation.config import Settings
 import pyautogui
 
-quiz_region = (100, 100, 600, 400)
-chatgpt_box = (800, 900)
-response_region = (100, 550, 600, 150)
-option_base = (100, 520)
+cfg = Settings()
 options = list("ABCD")
 
-img = pyautogui.screenshot(quiz_region)
-letter = answer_question_via_chatgpt(img, chatgpt_box, response_region, options, option_base, stats=Stats())
+img = pyautogui.screenshot(cfg.quiz_region)
+letter = answer_question_via_chatgpt(
+    img,
+    cfg.chat_box,
+    cfg.response_region,
+    options,
+    cfg.option_base,
+    stats=Stats(),
+)
 print(f"Model chose {letter}")
 ```
 This snippet grabs the current question, asks ChatGPT for help, and clicks the selected answer.  Adjust the coordinates to match your screen layout.
@@ -78,15 +89,20 @@ This snippet grabs the current question, asks ChatGPT for help, and clicks the s
 ## GUI example
 ```python
 from quiz_automation import QuizGUI, QuizRunner
+from quiz_automation.config import Settings
 
-quiz_region = (100, 100, 600, 400)
-chatgpt_box = (800, 900)
-response_region = (100, 550, 600, 150)
-option_base = (100, 520)
+cfg = Settings()
 options = list("ABCD")
 
 ui = QuizGUI()
-runner = QuizRunner(quiz_region, chatgpt_box, response_region, options, option_base, gui=ui)
+runner = QuizRunner(
+    cfg.quiz_region,
+    cfg.chat_box,
+    cfg.response_region,
+    options,
+    cfg.option_base,
+    gui=ui,
+)
 runner.start()             # capture + worker threads
 ```
 The window updates with question count, average response time, tokens, and errors as the runner progresses.

--- a/quiz_automation/config.py
+++ b/quiz_automation/config.py
@@ -15,6 +15,11 @@ class Settings(BaseSettings):
     model_name: str = "o4-mini-high"
     temperature: float = 0.0
 
+    quiz_region: tuple[int, int, int, int] = (100, 100, 600, 400)
+    chat_box: tuple[int, int] = (800, 900)
+    response_region: tuple[int, int, int, int] = (100, 550, 600, 150)
+    option_base: tuple[int, int] = (100, 520)
+
     model_config = SettingsConfigDict(env_prefix="", extra="ignore")
 
 

--- a/run.py
+++ b/run.py
@@ -2,25 +2,10 @@
 from __future__ import annotations
 
 import argparse
-import os
-from typing import Tuple
 
 from quiz_automation import QuizGUI
 from quiz_automation.runner import QuizRunner
-
-
-def _parse_tuple(env_name: str, default: Tuple[int, ...]) -> Tuple[int, ...]:
-    """Parse a comma-separated tuple from an environment variable."""
-
-    raw = os.getenv(env_name)
-    if raw:
-        try:
-            parts = tuple(int(p.strip()) for p in raw.split(","))
-            if len(parts) == len(default):
-                return parts
-        except ValueError:
-            pass
-    return default
+from quiz_automation.config import Settings
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -48,12 +33,15 @@ def main(argv: list[str] | None = None) -> None:
         else:
             print("PySide6 is not available; running without GUI.")
     else:
-        quiz_region = _parse_tuple("QUIZ_REGION", (100, 100, 600, 400))
-        chat_box = _parse_tuple("CHAT_BOX", (800, 900))
-        response_region = _parse_tuple("RESPONSE_REGION", (100, 550, 600, 150))
-        option_base = _parse_tuple("OPTION_BASE", (100, 520))
+        cfg = Settings()
         options = list("ABCD")
-        runner = QuizRunner(quiz_region, chat_box, response_region, options, option_base)
+        runner = QuizRunner(
+            cfg.quiz_region,
+            cfg.chat_box,
+            cfg.response_region,
+            options,
+            cfg.option_base,
+        )
         runner.start()
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,3 +19,14 @@ def test_config_default_poll_interval():
     cfg = Settings()
     assert cfg.poll_interval == 1.0
 
+
+def test_screen_region_defaults():
+    cfg = Settings()
+    assert cfg.quiz_region == (100, 100, 600, 400)
+
+
+def test_screen_region_env(monkeypatch):
+    monkeypatch.setenv("QUIZ_REGION", "[10,20,30,40]")
+    cfg = Settings()
+    assert cfg.quiz_region == (10, 20, 30, 40)
+

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -8,8 +8,18 @@ def test_headless_invokes_quiz_runner(monkeypatch):
     mock_runner = MagicMock(return_value=instance)
     monkeypatch.setattr(run, "QuizRunner", mock_runner)
 
+    cfg = MagicMock(
+        quiz_region=(1, 2, 3, 4),
+        chat_box=(5, 6),
+        response_region=(7, 8, 9, 10),
+        option_base=(11, 12),
+    )
+    monkeypatch.setattr(run, "Settings", lambda: cfg)
+
     run.main(["--mode", "headless"])
 
-    mock_runner.assert_called_once()
+    mock_runner.assert_called_once_with(
+        cfg.quiz_region, cfg.chat_box, cfg.response_region, list("ABCD"), cfg.option_base
+    )
     instance.start.assert_called_once_with()
 


### PR DESCRIPTION
## Summary
- move screen region defaults into `Settings`
- load configuration from `Settings` in the CLI
- document screen-region env vars and update examples

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689afb3f500c8328a250f42dcc9f491b