### PR TITLE
Default to first option when response lacks A–D

### DIFF
--- a/quiz_automation/automation.py
+++ b/quiz_automation/automation.py
@@ -162,6 +162,7 @@ def answer_question_via_chatgpt(
     except ValueError:
         # Fall back to alphabetical ordering; ensures a valid index even if the
         # model returns an unexpected string such as "E".
+        letter = letter or "A"
         idx = max(0, ord(letter) - ord("A"))
 
     click_option(option_base, idx)

--- a/tests/test_automation.py
+++ b/tests/test_automation.py
@@ -90,3 +90,26 @@ def test_click_option_missing_pyautogui(monkeypatch):
     with pytest.raises(RuntimeError):
         automation.click_option((0, 0), 0)
 
+
+def test_answer_question_fallback_to_first_option(monkeypatch):
+    """If ChatGPT's response lacks A-D the first option is used."""
+
+    calls: list[int] = []
+
+    monkeypatch.setattr(automation, "send_to_chatgpt", lambda img, box: None)
+    monkeypatch.setattr(
+        automation, "read_chatgpt_response", lambda region, timeout=20.0: "No option"
+    )
+
+    def fake_click_option(base, idx, offset=40):
+        calls.append(idx)
+
+    monkeypatch.setattr(automation, "click_option", fake_click_option)
+
+    letter = automation.answer_question_via_chatgpt(
+        "img", (0, 0), (0, 0, 1, 1), ["A", "B", "C"], (0, 0)
+    )
+
+    assert letter == "A"
+    assert calls == [0]
+


### PR DESCRIPTION
## Summary
- Ensure answer selection defaults to option A when ChatGPT returns no A–D letters
- Add regression test verifying the fallback chooses index 0

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689afb3d8bbc832884ebb0e9fd275852