### PR TITLE
Use Settings for screen region configuration

### DIFF
--- a/quiz_automation/config.py
+++ b/quiz_automation/config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 """Configuration handling for the quiz automation package."""
 
+from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -14,6 +15,20 @@ class Settings(BaseSettings):
     poll_interval: float = 1.0
     model_name: str = "o4-mini-high"
     temperature: float = 0.0
+
+    quiz_region: tuple[int, int, int, int] = (100, 100, 600, 400)
+    chat_box: tuple[int, int] = (800, 900)
+    response_region: tuple[int, int, int, int] = (100, 550, 600, 150)
+    option_base: tuple[int, int] = (100, 520)
+
+    @field_validator(
+        "quiz_region", "chat_box", "response_region", "option_base", mode="before"
+    )
+    @classmethod
+    def _parse_csv(cls, value: object) -> object:
+        if isinstance(value, str):
+            return tuple(int(part.strip()) for part in value.split(","))
+        return value
 
     model_config = SettingsConfigDict(env_prefix="", extra="ignore")
 

--- a/run.py
+++ b/run.py
@@ -2,25 +2,10 @@
 from __future__ import annotations
 
 import argparse
-import os
-from typing import Tuple
 
 from quiz_automation import QuizGUI
+from quiz_automation.config import Settings
 from quiz_automation.runner import QuizRunner
-
-
-def _parse_tuple(env_name: str, default: Tuple[int, ...]) -> Tuple[int, ...]:
-    """Parse a comma-separated tuple from an environment variable."""
-
-    raw = os.getenv(env_name)
-    if raw:
-        try:
-            parts = tuple(int(p.strip()) for p in raw.split(","))
-            if len(parts) == len(default):
-                return parts
-        except ValueError:
-            pass
-    return default
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -48,12 +33,11 @@ def main(argv: list[str] | None = None) -> None:
         else:
             print("PySide6 is not available; running without GUI.")
     else:
-        quiz_region = _parse_tuple("QUIZ_REGION", (100, 100, 600, 400))
-        chat_box = _parse_tuple("CHAT_BOX", (800, 900))
-        response_region = _parse_tuple("RESPONSE_REGION", (100, 550, 600, 150))
-        option_base = _parse_tuple("OPTION_BASE", (100, 520))
+        cfg = Settings()
         options = list("ABCD")
-        runner = QuizRunner(quiz_region, chat_box, response_region, options, option_base)
+        runner = QuizRunner(
+            cfg.quiz_region, cfg.chat_box, cfg.response_region, options, cfg.option_base
+        )
         runner.start()
 
 

--- a/tests/README
+++ b/tests/README
@@ -1,0 +1,14 @@
+Configuration values are loaded through `quiz_automation.config.Settings`.
+Screen-region defaults used by `run.py` can be overridden by setting
+environment variables before executing the tests. Provide values as
+comma-separated lists. For example:
+
+```
+export QUIZ_REGION="100,100,600,400"
+export CHAT_BOX="800,900"
+export RESPONSE_REGION="100,550,600,150"
+export OPTION_BASE="100,520"
+```
+
+The defaults defined in `Settings` are used when these variables are absent.
+


### PR DESCRIPTION
## Summary
- expose default screen regions via `quiz_automation.config.Settings`
- use `Settings` in `run.py` instead of manual tuple parsing
- document environment variable overrides in `tests/README`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689afc00edd08328a4fab2a04a9bf4f0