### PR TITLE
Default to option A when response lacks letter

### DIFF
--- a/quiz_automation/automation.py
+++ b/quiz_automation/automation.py
@@ -155,14 +155,14 @@ def answer_question_via_chatgpt(
     send_to_chatgpt(quiz_image, chatgpt_box)
     response = read_chatgpt_response(response_region)
     matches = re.findall(r"[A-D]", response.upper())
-    letter = matches[-1] if matches else ""
+    letter = matches[-1] if matches else "A"
 
     try:
         idx = options.index(letter)
     except ValueError:
         # Fall back to alphabetical ordering; ensures a valid index even if the
         # model returns an unexpected string such as "E".
-        idx = max(0, ord(letter) - ord("A"))
+        idx = max(0, ord(letter) - ord("A")) if letter else 0
 
     click_option(option_base, idx)
     logger.info("ChatGPT chose %s", letter)

--- a/tests/test_automation.py
+++ b/tests/test_automation.py
@@ -90,3 +90,25 @@ def test_click_option_missing_pyautogui(monkeypatch):
     with pytest.raises(RuntimeError):
         automation.click_option((0, 0), 0)
 
+
+def test_answer_question_defaults_to_a(monkeypatch):
+    """When no letter A-D is found the first option is chosen."""
+
+    clicks = []
+    monkeypatch.setattr(automation, "send_to_chatgpt", lambda img, box: None)
+    monkeypatch.setattr(
+        automation, "read_chatgpt_response", lambda region, timeout=20.0: "zzz"
+    )
+
+    def fake_click(base, index, offset=40):
+        clicks.append(index)
+
+    monkeypatch.setattr(automation, "click_option", fake_click)
+
+    letter = automation.answer_question_via_chatgpt(
+        "img", (0, 0), (0, 0, 0, 0), ["A", "B", "C", "D"], (10, 10)
+    )
+
+    assert letter == "A"
+    assert clicks == [0]
+


### PR DESCRIPTION
## Summary
- fall back to letter A when no A-D match is extracted
- guard ord(letter) to avoid TypeError
- test defaulting to the first option when no letter is found

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689afc000c188328ac72d298693a998b