### PR TITLE
Handle QuizRunner lifecycle and add join test

### DIFF
--- a/quiz_automation/runner.py
+++ b/quiz_automation/runner.py
@@ -29,7 +29,7 @@ class QuizRunner(threading.Thread):
         stats: Stats | None = None,
         gui: QuizGUI | None = None,
     ) -> None:
-        super().__init__(daemon=True)
+        super().__init__()
         self.quiz_region = quiz_region
         self.chatgpt_box = chatgpt_box
         self.response_region = response_region

--- a/run.py
+++ b/run.py
@@ -54,7 +54,12 @@ def main(argv: list[str] | None = None) -> None:
         option_base = _parse_tuple("OPTION_BASE", (100, 520))
         options = list("ABCD")
         runner = QuizRunner(quiz_region, chat_box, response_region, options, option_base)
-        runner.start()
+        try:
+            runner.start()
+            runner.join()
+        except KeyboardInterrupt:
+            runner.stop()
+            runner.join()
 
 
 if __name__ == "__main__":

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -12,4 +12,5 @@ def test_headless_invokes_quiz_runner(monkeypatch):
 
     mock_runner.assert_called_once()
     instance.start.assert_called_once_with()
+    instance.join.assert_called_once_with()
 


### PR DESCRIPTION
## Summary
- Block the main thread by joining `QuizRunner` and removing daemon mode
- Stop runner gracefully on `KeyboardInterrupt`
- Verify `join()` is invoked in headless mode tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689afbff027883289eb9536fd696c0f7