### PR TITLE
Add configurable poll interval for ChatGPT response polling

### DIFF
--- a/quiz_automation/automation.py
+++ b/quiz_automation/automation.py
@@ -78,6 +78,7 @@ def send_to_chatgpt(img: Any, box: Tuple[int, int]) -> None:
 def read_chatgpt_response(
     response_region: Tuple[int, int, int, int],
     timeout: float = 20.0,
+    poll_interval: float = 0.5,
 ) -> str:
     """Return OCR'd text from ``response_region`` until non-empty or timeout.
 
@@ -88,6 +89,8 @@ def read_chatgpt_response(
         ChatGPT's textual response.
     timeout:
         Maximum number of seconds to wait for a non-empty OCR result.
+    poll_interval:
+        Seconds to wait between OCR attempts.
 
     Returns
     -------
@@ -114,7 +117,7 @@ def read_chatgpt_response(
         text = pytesseract.image_to_string(img).strip()
         if text:
             return text
-        time.sleep(0.5)
+        time.sleep(poll_interval)
 
     raise TimeoutError("No response detected")
 
@@ -143,17 +146,19 @@ def answer_question_via_chatgpt(
     options: Sequence[str],
     option_base: Tuple[int, int],
     stats: Stats | None = None,
+    poll_interval: float = 0.5,
 ) -> str:
     """Send ``quiz_image`` to ChatGPT and click the model's chosen answer.
 
     The function blocks until text appears in ``response_region`` or raises a
     :class:`TimeoutError`.  The returned string is the letter that was clicked.
-    ``stats`` can be supplied to record per-question metrics.
+    ``stats`` can be supplied to record per-question metrics. ``poll_interval``
+    controls how frequently the ChatGPT response region is polled.
     """
 
     start = time.time()
     send_to_chatgpt(quiz_image, chatgpt_box)
-    response = read_chatgpt_response(response_region)
+    response = read_chatgpt_response(response_region, poll_interval=poll_interval)
     matches = re.findall(r"[A-D]", response.upper())
     letter = matches[-1] if matches else ""
 

--- a/quiz_automation/runner.py
+++ b/quiz_automation/runner.py
@@ -28,6 +28,7 @@ class QuizRunner(threading.Thread):
         *,
         stats: Stats | None = None,
         gui: QuizGUI | None = None,
+        poll_interval: float = 0.5,
     ) -> None:
         super().__init__(daemon=True)
         self.quiz_region = quiz_region
@@ -38,6 +39,7 @@ class QuizRunner(threading.Thread):
         self.stop_flag = threading.Event()
         self.stats = stats or Stats()
         self.gui = gui
+        self.poll_interval = poll_interval
 
     def stop(self) -> None:
         """Signal the runner to stop."""
@@ -70,6 +72,7 @@ class QuizRunner(threading.Thread):
                         self.options,
                         self.option_base,
                         stats=self.stats,
+                        poll_interval=self.poll_interval,
                     )
                 except Exception:
                     logger.exception("Error while answering question")

--- a/tests/test_automation.py
+++ b/tests/test_automation.py
@@ -38,15 +38,27 @@ def test_send_to_chatgpt_copy_failure(monkeypatch):
         automation.send_to_chatgpt("img", (0, 0))
 
 
-def test_read_chatgpt_response_success(monkeypatch):
-    """Return OCR text once non-empty."""
+def test_read_chatgpt_response_default_poll_interval(monkeypatch):
+    """Default ``poll_interval`` of 0.5 seconds is used."""
 
     monkeypatch.setattr(automation, "pyautogui", types.SimpleNamespace(screenshot=lambda region: "img"))
-    monkeypatch.setattr(automation, "pytesseract", types.SimpleNamespace(image_to_string=lambda img: " hello "))
+    responses = iter(["", " hello "])
+    monkeypatch.setattr(
+        automation,
+        "pytesseract",
+        types.SimpleNamespace(image_to_string=lambda img: next(responses)),
+    )
     monkeypatch.setattr(automation, "validate_region", lambda region: None)
+    sleeps: list[float] = []
+    monkeypatch.setattr(
+        automation,
+        "time",
+        types.SimpleNamespace(time=lambda: 0, sleep=lambda s: sleeps.append(s)),
+    )
 
-    text = automation.read_chatgpt_response((0, 0, 1, 1), timeout=0.1)
+    text = automation.read_chatgpt_response((0, 0, 1, 1))
     assert text == "hello"
+    assert sleeps == [0.5]
 
 
 def test_read_chatgpt_response_timeout(monkeypatch):
@@ -59,6 +71,29 @@ def test_read_chatgpt_response_timeout(monkeypatch):
 
     with pytest.raises(TimeoutError):
         automation.read_chatgpt_response((0, 0, 1, 1), timeout=1.0)
+
+
+def test_read_chatgpt_response_custom_poll_interval(monkeypatch):
+    """A custom ``poll_interval`` is honoured."""
+
+    monkeypatch.setattr(automation, "pyautogui", types.SimpleNamespace(screenshot=lambda region: "img"))
+    responses = iter(["", " hello "])
+    monkeypatch.setattr(
+        automation,
+        "pytesseract",
+        types.SimpleNamespace(image_to_string=lambda img: next(responses)),
+    )
+    monkeypatch.setattr(automation, "validate_region", lambda region: None)
+    sleeps: list[float] = []
+    monkeypatch.setattr(
+        automation,
+        "time",
+        types.SimpleNamespace(time=lambda: 0, sleep=lambda s: sleeps.append(s)),
+    )
+
+    text = automation.read_chatgpt_response((0, 0, 1, 1), poll_interval=0.1)
+    assert text == "hello"
+    assert sleeps == [0.1]
 
 
 def test_click_option_uses_clicker(monkeypatch):
@@ -98,7 +133,9 @@ def test_answer_question_fallback_to_first_option(monkeypatch):
 
     monkeypatch.setattr(automation, "send_to_chatgpt", lambda img, box: None)
     monkeypatch.setattr(
-        automation, "read_chatgpt_response", lambda region, timeout=20.0: "No option"
+        automation,
+        "read_chatgpt_response",
+        lambda region, timeout=20.0, poll_interval=0.5: "No option",
     )
 
     def fake_click_option(base, idx, offset=40):
@@ -112,4 +149,25 @@ def test_answer_question_fallback_to_first_option(monkeypatch):
 
     assert letter == "A"
     assert calls == [0]
+
+
+def test_answer_question_custom_poll_interval(monkeypatch):
+    """``answer_question_via_chatgpt`` forwards ``poll_interval``."""
+
+    calls: list[float] = []
+
+    monkeypatch.setattr(automation, "send_to_chatgpt", lambda img, box: None)
+
+    def fake_read(region, timeout=20.0, poll_interval=0.5):
+        calls.append(poll_interval)
+        return "Answer A"
+
+    monkeypatch.setattr(automation, "read_chatgpt_response", fake_read)
+    monkeypatch.setattr(automation, "click_option", lambda base, idx, offset=40: None)
+
+    letter = automation.answer_question_via_chatgpt(
+        "img", (0, 0), (0, 0, 1, 1), ["A", "B"], (0, 0), poll_interval=0.2
+    )
+    assert letter == "A"
+    assert calls == [0.2]
 

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -23,7 +23,11 @@ def test_automation_logs_message(monkeypatch, caplog):
     caplog.set_level(logging.INFO, logger="quiz_automation.automation")
 
     monkeypatch.setattr(automation, "send_to_chatgpt", lambda img, box: None)
-    monkeypatch.setattr(automation, "read_chatgpt_response", lambda region, timeout=20.0: "Answer B")
+    monkeypatch.setattr(
+        automation,
+        "read_chatgpt_response",
+        lambda region, timeout=20.0, poll_interval=0.5: "Answer B",
+    )
     monkeypatch.setattr(automation, "click_option", lambda base, idx, offset=40: None)
 
     letter = automation.answer_question_via_chatgpt(

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -18,7 +18,7 @@ def test_runner_triggers_full_flow(monkeypatch):
 
     monkeypatch.setattr(automation, "send_to_chatgpt", fake_send)
 
-    def fake_read(region, timeout=20.0):
+    def fake_read(region, timeout=20.0, poll_interval=0.5):
         calls["read"] += 1
         return "Answer A"
 


### PR DESCRIPTION
## Summary
- allow setting a `poll_interval` in `read_chatgpt_response` to tune OCR polling
- propagate `poll_interval` through `answer_question_via_chatgpt` and `QuizRunner`
- test default and custom polling intervals

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689b0e7b0d6c832883cf26c78847d045