### PR TITLE
Remove unused model_name setting and alias openai model

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The requirements file installs everything needed to run the full automation.  Fo
 The package installs a `quiz-automation` script that wraps the command‑line interface in `run.py`.
 
 ### Environment variables
-Set `OPENAI_API_KEY` for access to the OpenAI API.  Additional settings read by the tool include `OPENAI_MODEL`, `OPENAI_SYSTEM_PROMPT`, `POLL_INTERVAL`, `MODEL_NAME`, and `TEMPERATURE`.
+Set `OPENAI_API_KEY` for access to the OpenAI API.  Additional settings read by the tool include `OPENAI_MODEL`, `OPENAI_SYSTEM_PROMPT`, `POLL_INTERVAL`, and `TEMPERATURE`.
 
 Screen regions can be customized with `QUIZ_REGION`, `CHAT_BOX`, `RESPONSE_REGION`, and `OPTION_BASE`. Each is a JSON array of integers such as `QUIZ_REGION=[100,100,600,400]`.
 
@@ -37,7 +37,6 @@ OPENAI_API_KEY=sk-your-api-key
 OPENAI_MODEL=o4-mini-high
 # OPENAI_SYSTEM_PROMPT="Reply with JSON {'answer':'A|B|C|D'}"
 # POLL_INTERVAL=1.0
-# MODEL_NAME=o4-mini-high
 # TEMPERATURE=0.0
 # QUIZ_REGION=[100,100,600,400]
 # CHAT_BOX=[800,900]

--- a/quiz_automation/chatgpt_client.py
+++ b/quiz_automation/chatgpt_client.py
@@ -34,7 +34,7 @@ class ChatGPTClient:
 
     def _completion(self, prompt: str) -> str:
         response = self.client.responses.create(
-            model=settings.openai_model,
+            model=settings.model,
             input=[
                 {"role": "system", "content": settings.openai_system_prompt},
                 {"role": "user", "content": prompt},

--- a/quiz_automation/config.py
+++ b/quiz_automation/config.py
@@ -12,7 +12,6 @@ class Settings(BaseSettings):
     openai_model: str = "o4-mini-high"
     openai_system_prompt: str = "Reply with JSON {'answer':'A|B|C|D'}"
     poll_interval: float = 1.0
-    model_name: str = "o4-mini-high"
     temperature: float = 0.0
 
     quiz_region: tuple[int, int, int, int] = (100, 100, 600, 400)
@@ -21,6 +20,15 @@ class Settings(BaseSettings):
     option_base: tuple[int, int] = (100, 520)
 
     model_config = SettingsConfigDict(env_prefix="", extra="ignore")
+
+    @property
+    def model(self) -> str:
+        """Alias for ``openai_model`` for backward compatibility."""
+        return self.openai_model
+
+    @model.setter
+    def model(self, value: str) -> None:  # pragma: no cover - simple assignment
+        self.openai_model = value
 
 
 # A module-level settings instance convenient for components that do not need

--- a/tests/test_chatgpt_client.py
+++ b/tests/test_chatgpt_client.py
@@ -34,7 +34,7 @@ def test_chatgpt_client_parses_json_response(monkeypatch):
 
 
 def test_chatgpt_client_uses_settings(monkeypatch):
-    monkeypatch.setattr(settings, "openai_model", "my-model")
+    monkeypatch.setattr(settings, "model", "my-model")
     monkeypatch.setattr(settings, "openai_system_prompt", "my prompt")
     client = _setup_client(monkeypatch)
     client.ask("Q?")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,6 +11,7 @@ def test_openai_config_overrides(monkeypatch):
     monkeypatch.setenv("OPENAI_MODEL", "foo")
     monkeypatch.setenv("OPENAI_SYSTEM_PROMPT", "prompt")
     cfg = Settings()
+    assert cfg.model == "foo"
     assert cfg.openai_model == "foo"
     assert cfg.openai_system_prompt == "prompt"
 


### PR DESCRIPTION
## Summary
- drop redundant `model_name` config option
- expose `Settings.model` as alias for `openai_model`
- update modules, tests, and docs to use the new alias

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b0e79cdd88328b19fae4a5ac95013