### PR TITLE
Use running totals for quiz stats

### DIFF
--- a/quiz_automation/stats.py
+++ b/quiz_automation/stats.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from threading import Lock
-from typing import List
 
 
 @dataclass
@@ -17,8 +16,8 @@ class Stats:
     :attr:`questions_answered` or :attr:`average_time` to display live metrics.
     """
 
-    question_times: List[float] = field(default_factory=list)
-    token_counts: List[int] = field(default_factory=list)
+    total_time: float = 0.0
+    total_tokens: int = 0
     questions_answered: int = 0
     errors: int = 0
     _lock: Lock = field(default_factory=Lock, init=False, repr=False)
@@ -28,8 +27,8 @@ class Stats:
 
         with self._lock:
             self.questions_answered += 1
-            self.question_times.append(duration)
-            self.token_counts.append(tokens)
+            self.total_time += duration
+            self.total_tokens += tokens
 
     def record_error(self) -> None:
         """Increment the error counter."""
@@ -42,15 +41,15 @@ class Stats:
         """Return the average time taken per question."""
 
         with self._lock:
-            if not self.question_times:
+            if self.questions_answered == 0:
                 return 0.0
-            return sum(self.question_times) / len(self.question_times)
+            return self.total_time / self.questions_answered
 
     @property
     def average_tokens(self) -> float:
         """Return the average tokens used per question."""
 
         with self._lock:
-            if not self.token_counts:
+            if self.questions_answered == 0:
                 return 0.0
-            return sum(self.token_counts) / len(self.token_counts)
+            return self.total_tokens / self.questions_answered

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -11,9 +11,11 @@ def test_record_updates_counts_and_averages() -> None:
     stats.record(2.0, 6)
 
     assert stats.questions_answered == 2
-    # Average of [1.0, 2.0]
+    assert stats.total_time == pytest.approx(3.0)
+    assert stats.total_tokens == 10
+    # Average of recorded times
     assert stats.average_time == pytest.approx(1.5)
-    # Average of [4, 6]
+    # Average of recorded token counts
     assert stats.average_tokens == pytest.approx(5.0)
 
 


### PR DESCRIPTION
## Summary
- track total time and tokens instead of storing per-question lists
- compute averages from running totals
- update stats tests for new aggregation approach

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689b0e7bebf88328b28f8ec9efff7cc7