### PR TITLE
Refactor clipboard helper and add OS-specific tests

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,43 +17,146 @@ def test_hash_text_different():
 
 
 class DummyImage:
-    def save(self, fp, fmt):  # pragma: no cover - simple helper
-        fp.write(b"data")
+    def convert(self, mode):  # pragma: no cover - simple helper
+        return self
+
+    def save(self, fp, fmt=None, **_: object):  # pragma: no cover - simple helper
+        fp.write(b"x" * 20)
 
 
-def test_copy_image_linux(monkeypatch):
-    called = {}
+def test_copy_image_windows(monkeypatch):
+    calls = []
+
+    def open_clipboard():
+        calls.append("open")
+
+    def close_clipboard():
+        calls.append("close")
+
+    def empty_clipboard():
+        calls.append("empty")
+
+    def set_clipboard_data(fmt, data):
+        calls.append("set")
+
+    fake = SimpleNamespace(
+        CF_DIB=1,
+        OpenClipboard=open_clipboard,
+        CloseClipboard=close_clipboard,
+        EmptyClipboard=empty_clipboard,
+        SetClipboardData=set_clipboard_data,
+    )
+
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setitem(sys.modules, "win32clipboard", fake)
+
+    assert copy_image_to_clipboard(DummyImage()) is True
+    assert calls == ["open", "empty", "set", "close"]
+
+
+def test_copy_image_macos(monkeypatch):
+    calls: dict[str, object] = {}
+
+    class DummyStdin(io.BytesIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            calls["stdin_closed"] = True
+            self.close()
 
     class DummyProc:
         def __init__(self):
-            self.stdin = io.BytesIO()
+            self.stdin = DummyStdin()
+
+        def __enter__(self):
+            calls["enter"] = True
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            calls["exit"] = True
+            self.wait()
 
         def wait(self):
-            called["wait"] = True
+            calls["wait"] = True
 
     def fake_popen(cmd, stdin=None, close_fds=True):
-        called["cmd"] = cmd
+        calls["cmd"] = cmd
         return DummyProc()
 
+    monkeypatch.setattr(sys, "platform", "darwin")
     monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
     assert copy_image_to_clipboard(DummyImage()) is True
-    assert called["cmd"][:3] == ["xclip", "-selection", "clipboard"]
+    assert calls["cmd"] == ["pbcopy"]
+    assert calls["wait"] is True and calls.get("stdin_closed") is True
 
 
-def test_copy_image_failure(monkeypatch, caplog):
-    class DummyImage:
-        def save(self, fp, fmt):  # pragma: no cover - simple helper
-            fp.write(b"data")
+def test_copy_image_linux(monkeypatch):
+    calls: dict[str, object] = {}
 
+    class DummyStdin(io.BytesIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            calls["stdin_closed"] = True
+            self.close()
+
+    class DummyProc:
+        def __init__(self):
+            self.stdin = DummyStdin()
+
+        def __enter__(self):
+            calls["enter"] = True
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            calls["exit"] = True
+            self.wait()
+
+        def wait(self):
+            calls["wait"] = True
+
+    def fake_popen(cmd, stdin=None, close_fds=True):
+        calls["cmd"] = cmd
+        return DummyProc()
+
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    assert copy_image_to_clipboard(DummyImage()) is True
+    assert calls["cmd"][:3] == ["xclip", "-selection", "clipboard"]
+    assert calls["wait"] is True and calls.get("stdin_closed") is True
+
+
+def test_copy_image_fallback(monkeypatch):
     def fail_popen(*args, **kwargs):
         raise OSError("boom")
 
+    captured: dict[str, str] = {}
+
+    def fake_copy(data):
+        captured["data"] = data
+
+    monkeypatch.setattr(sys, "platform", "linux")
     monkeypatch.setattr(subprocess, "Popen", fail_popen)
-    monkeypatch.setitem(
-        sys.modules,
-        "pyperclip",
-        SimpleNamespace(copy=lambda *_: (_ for _ in ()).throw(RuntimeError("fail"))),
-    )
+    monkeypatch.setitem(sys.modules, "pyperclip", SimpleNamespace(copy=fake_copy))
+
+    assert copy_image_to_clipboard(DummyImage()) is True
+    assert "data" in captured
+
+
+def test_copy_image_failure(monkeypatch, caplog):
+    def fail_popen(*args, **kwargs):
+        raise OSError("boom")
+
+    def fail_copy(data):
+        raise RuntimeError("fail")
+
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(subprocess, "Popen", fail_popen)
+    monkeypatch.setitem(sys.modules, "pyperclip", SimpleNamespace(copy=fail_copy))
 
     with caplog.at_level("ERROR"):
         assert copy_image_to_clipboard(DummyImage()) is False


### PR DESCRIPTION
## Summary
- Split `copy_image_to_clipboard` into platform-specific helpers and a Windows clipboard context manager
- Use `with` statements for subprocess and clipboard resource management
- Add unit tests covering Windows, macOS, Linux, fallback, and failure paths

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b0e7eb8f08328980cc84f119103ba