### PR TITLE
feat: add log level and config CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ Running the command in a headless environment only needs `pydantic`, `pydantic-s
 * `PySide6` – GUI for live statistics
 
 ### Running
-Invoke the script with a mode flag:
+Invoke the script with a mode flag. Optional arguments control logging and
+configuration loading:
 
 ```bash
 # headless
@@ -62,7 +63,14 @@ quiz-automation --mode headless
 
 # GUI
 quiz-automation --mode gui
+
+# custom config and debug logging
+quiz-automation --mode headless --log-level DEBUG --config settings.env
 ```
+
+`--log-level` sets the logging verbosity (e.g., ``DEBUG``, ``INFO``) and
+`--config` points to a ``.env``-style file loaded before instantiating the
+``Settings`` class.
 
 ## CLI example
 ```python

--- a/run.py
+++ b/run.py
@@ -2,10 +2,12 @@
 from __future__ import annotations
 
 import argparse
+import logging
 
 from quiz_automation import QuizGUI
 from quiz_automation.runner import QuizRunner
 from quiz_automation.config import Settings
+from quiz_automation.logger import configure_logger
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -23,7 +25,19 @@ def main(argv: list[str] | None = None) -> None:
         default="gui",
         help="Choose whether to launch the GUI or run in headless mode.",
     )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        help="Logging level for the application",
+    )
+    parser.add_argument(
+        "--config",
+        help="Path to a configuration file read by the Settings class",
+    )
     args = parser.parse_args(argv)
+
+    level = getattr(logging, args.log_level.upper(), logging.INFO)
+    configure_logger(level=level)
 
     if args.mode == "gui":
         gui = QuizGUI()
@@ -33,7 +47,7 @@ def main(argv: list[str] | None = None) -> None:
         else:
             print("PySide6 is not available; running without GUI.")
     else:
-        cfg = Settings()
+        cfg = Settings(_env_file=args.config) if args.config else Settings()
         options = list("ABCD")
         runner = QuizRunner(
             cfg.quiz_region,

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,4 +1,5 @@
 from unittest.mock import MagicMock
+import logging
 
 import run
 
@@ -14,12 +15,53 @@ def test_headless_invokes_quiz_runner(monkeypatch):
         response_region=(7, 8, 9, 10),
         option_base=(11, 12),
     )
-    monkeypatch.setattr(run, "Settings", lambda: cfg)
+    mock_settings = MagicMock(return_value=cfg)
+    monkeypatch.setattr(run, "Settings", mock_settings)
+
+    mock_configure = MagicMock()
+    monkeypatch.setattr(run, "configure_logger", mock_configure)
 
     run.main(["--mode", "headless"])
 
+    mock_settings.assert_called_once_with()
+    mock_configure.assert_called_once()
+    assert mock_configure.call_args.kwargs["level"] == logging.INFO
     mock_runner.assert_called_once_with(
         cfg.quiz_region, cfg.chat_box, cfg.response_region, list("ABCD"), cfg.option_base
     )
     instance.start.assert_called_once_with()
+
+
+def test_config_and_log_level_flags(monkeypatch, tmp_path):
+    cfg = MagicMock(
+        quiz_region=(1, 2, 3, 4),
+        chat_box=(5, 6),
+        response_region=(7, 8, 9, 10),
+        option_base=(11, 12),
+    )
+    mock_settings = MagicMock(return_value=cfg)
+    monkeypatch.setattr(run, "Settings", mock_settings)
+
+    mock_runner = MagicMock()
+    monkeypatch.setattr(run, "QuizRunner", mock_runner)
+
+    mock_configure = MagicMock()
+    monkeypatch.setattr(run, "configure_logger", mock_configure)
+
+    config_file = tmp_path / "test.env"
+    config_file.write_text("POLL_INTERVAL=2")
+
+    run.main([
+        "--mode",
+        "headless",
+        "--log-level",
+        "DEBUG",
+        "--config",
+        str(config_file),
+    ])
+
+    mock_configure.assert_called_once()
+    assert mock_configure.call_args.kwargs["level"] == logging.DEBUG
+    mock_settings.assert_called_once_with(_env_file=str(config_file))
+    mock_runner.assert_called_once()
 


### PR DESCRIPTION
## Summary
- add `--log-level` and `--config` CLI flags
- load settings from config file when provided
- document new CLI flags and cover parsing in tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b0e8095bc8328ad5410c85d33b4f4