### PR TITLE
feat: support pluggable OCR backends

### DIFF
--- a/quiz_automation/config.py
+++ b/quiz_automation/config.py
@@ -14,6 +14,7 @@ class Settings(BaseSettings):
     poll_interval: float = 1.0
     model_name: str = "o4-mini-high"
     temperature: float = 0.0
+    ocr_backend: str | None = None
 
     quiz_region: tuple[int, int, int, int] = (100, 100, 600, 400)
     chat_box: tuple[int, int] = (800, 900)

--- a/quiz_automation/ocr.py
+++ b/quiz_automation/ocr.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 """OCR backends used by the quiz watcher."""
 
-from typing import Protocol
+from importlib import import_module
+from typing import Any, Callable, Dict, Protocol
 
 
 class OCRBackend(Protocol):
@@ -38,3 +39,54 @@ class PytesseractOCR:
         else:  # pragma: no cover - passthrough for already supported objects
             pil_img = img
         return pytesseract.image_to_string(pil_img, lang=self.lang)
+
+
+# -- backend registry ---------------------------------------------------
+
+_BACKENDS: Dict[str, Callable[..., OCRBackend]] = {"pytesseract": PytesseractOCR}
+
+
+def register_backend(name: str, backend: Callable[..., OCRBackend] | type[OCRBackend]) -> None:
+    """Register *backend* under *name*.
+
+    ``backend`` may be a class implementing :class:`OCRBackend` or a callable
+    returning such an object.
+    """
+
+    _BACKENDS[name] = backend  # type: ignore[assignment]
+
+
+def get_backend(name: str | None = None, **kwargs: Any) -> OCRBackend:
+    """Return an OCR backend from *name*.
+
+    When *name* is ``None`` the default ``pytesseract`` backend is returned.
+    If *name* matches a registered backend the associated factory is invoked.
+    Otherwise *name* is treated as an import path of the form
+    ``'module:qualname'`` or ``'module.qualname'`` and imported dynamically.
+    """
+
+    target = name or "pytesseract"
+    factory = _BACKENDS.get(target)
+    if factory is not None:
+        if isinstance(factory, type):
+            return factory(**kwargs)  # type: ignore[misc]
+        return factory(**kwargs)
+
+    module_name, sep, qualname = target.replace(":", ".").rpartition(".")
+    if not sep:
+        raise RuntimeError(f"Unknown OCR backend '{target}'")
+    module = import_module(module_name)
+    obj = getattr(module, qualname)
+    if isinstance(obj, type):
+        return obj(**kwargs)  # type: ignore[misc]
+    if callable(obj):
+        return obj(**kwargs)
+    raise RuntimeError(f"OCR backend '{target}' is not callable")
+
+
+__all__ = [
+    "OCRBackend",
+    "PytesseractOCR",
+    "register_backend",
+    "get_backend",
+]

--- a/quiz_automation/watcher.py
+++ b/quiz_automation/watcher.py
@@ -9,7 +9,7 @@ from queue import Queue
 from typing import Tuple
 
 from .config import Settings
-from .ocr import OCRBackend, PytesseractOCR
+from .ocr import OCRBackend, get_backend
 from .utils import hash_text
 
 logger = logging.getLogger(__name__)
@@ -43,7 +43,7 @@ class Watcher(threading.Thread):
         self.stop_flag = threading.Event()
         self.pause_flag = threading.Event()
         self._last_hash: str | None = None
-        self.ocr_backend = ocr or PytesseractOCR()
+        self.ocr_backend = ocr or get_backend(cfg.ocr_backend)
 
     # -- basic helpers -------------------------------------------------
     def capture(self):

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -1,0 +1,20 @@
+import quiz_automation.ocr as ocr_module
+
+class DummyBackendOne:
+    def __call__(self, img):  # pragma: no cover - simple stub
+        return "one"
+
+class DummyBackendTwo:
+    def __call__(self, img):  # pragma: no cover - simple stub
+        return "two"
+
+def test_get_backend_registered(monkeypatch):
+    monkeypatch.setattr(ocr_module, "_BACKENDS", dict(ocr_module._BACKENDS))
+    ocr_module.register_backend("one", DummyBackendOne)
+    backend = ocr_module.get_backend("one")
+    assert backend("img") == "one"
+
+
+def test_get_backend_dynamic_import():
+    backend = ocr_module.get_backend("tests.test_ocr:DummyBackendTwo")
+    assert backend("img") == "two"

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -6,6 +6,7 @@ import pytest
 
 from quiz_automation import watcher as watcher_module
 from quiz_automation.config import Settings
+import quiz_automation.ocr as ocr_module
 from quiz_automation.ocr import PytesseractOCR
 from quiz_automation.watcher import Watcher
 
@@ -21,6 +22,21 @@ def test_default_ocr_backend(monkeypatch):
     cfg = Settings()
     w = Watcher((0, 0, 1, 1), Queue(), cfg)
     assert isinstance(w.ocr_backend, PytesseractOCR)
+
+
+def test_configured_ocr_backend(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    monkeypatch.setattr(watcher_module, "_mss", lambda: type("S", (), {"mss": lambda self=None: DummyMSS()})())
+    monkeypatch.setattr(ocr_module, "_BACKENDS", dict(ocr_module._BACKENDS))
+
+    class DummyBackend:
+        def __call__(self, img):  # pragma: no cover - simple stub
+            return "dummy"
+
+    ocr_module.register_backend("dummy", DummyBackend)
+    cfg = Settings(ocr_backend="dummy")
+    w = Watcher((0, 0, 1, 1), Queue(), cfg)
+    assert isinstance(w.ocr_backend, DummyBackend)
 
 
 def test_watcher_is_new_question(monkeypatch):


### PR DESCRIPTION
## Summary
- add optional `ocr_backend` setting and dynamic backend loader
- load OCR backend via registry or import path
- cover backend switching and dynamic import with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b0e81497c83288b82e8d24200e661