### PR TITLE
Graceful runner shutdown and max question limit

### DIFF
--- a/run.py
+++ b/run.py
@@ -8,6 +8,7 @@ from quiz_automation import QuizGUI
 from quiz_automation.runner import QuizRunner
 from quiz_automation.config import Settings
 from quiz_automation.logger import configure_logger
+from quiz_automation.stats import Stats
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -34,6 +35,11 @@ def main(argv: list[str] | None = None) -> None:
         "--config",
         help="Path to a configuration file read by the Settings class",
     )
+    parser.add_argument(
+        "--max-questions",
+        type=int,
+        help="Automatically stop after answering this many questions",
+    )
     args = parser.parse_args(argv)
 
     level = getattr(logging, args.log_level.upper(), logging.INFO)
@@ -49,14 +55,30 @@ def main(argv: list[str] | None = None) -> None:
     else:
         cfg = Settings(_env_file=args.config) if args.config else Settings()
         options = list("ABCD")
+        stats = Stats()
         runner = QuizRunner(
             cfg.quiz_region,
             cfg.chat_box,
             cfg.response_region,
             options,
             cfg.option_base,
+            stats=stats,
         )
         runner.start()
+        try:
+            while True:
+                runner.join(timeout=1)
+                if not runner.is_alive():
+                    break
+                if (
+                    args.max_questions is not None
+                    and stats.questions_answered >= args.max_questions
+                ):
+                    runner.stop()
+        except KeyboardInterrupt:
+            runner.stop()
+        finally:
+            runner.join()
 
 
 if __name__ == "__main__":

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -7,6 +7,7 @@ from quiz_automation.types import Point, Region
 
 def test_headless_invokes_quiz_runner(monkeypatch):
     instance = MagicMock()
+    instance.is_alive.return_value = False
     mock_runner = MagicMock(return_value=instance)
     monkeypatch.setattr(run, "QuizRunner", mock_runner)
 
@@ -27,10 +28,18 @@ def test_headless_invokes_quiz_runner(monkeypatch):
     mock_settings.assert_called_once_with()
     mock_configure.assert_called_once()
     assert mock_configure.call_args.kwargs["level"] == logging.INFO
-    mock_runner.assert_called_once_with(
-        cfg.quiz_region, cfg.chat_box, cfg.response_region, list("ABCD"), cfg.option_base
+    mock_runner.assert_called_once()
+    args, kwargs = mock_runner.call_args
+    assert args == (
+        cfg.quiz_region,
+        cfg.chat_box,
+        cfg.response_region,
+        list("ABCD"),
+        cfg.option_base,
     )
+    assert "stats" in kwargs
     instance.start.assert_called_once_with()
+    instance.join.assert_called()
 
 
 def test_config_and_log_level_flags(monkeypatch, tmp_path):
@@ -43,7 +52,9 @@ def test_config_and_log_level_flags(monkeypatch, tmp_path):
     mock_settings = MagicMock(return_value=cfg)
     monkeypatch.setattr(run, "Settings", mock_settings)
 
-    mock_runner = MagicMock()
+    instance = MagicMock()
+    instance.is_alive.return_value = False
+    mock_runner = MagicMock(return_value=instance)
     monkeypatch.setattr(run, "QuizRunner", mock_runner)
 
     mock_configure = MagicMock()
@@ -65,4 +76,39 @@ def test_config_and_log_level_flags(monkeypatch, tmp_path):
     assert mock_configure.call_args.kwargs["level"] == logging.DEBUG
     mock_settings.assert_called_once_with(_env_file=str(config_file))
     mock_runner.assert_called_once()
+    instance.join.assert_called()
+
+
+def test_max_questions_stops_runner(monkeypatch):
+    stats = run.Stats()
+    stats.questions_answered = 0
+
+    def stats_factory():
+        return stats
+
+    monkeypatch.setattr(run, "Stats", stats_factory)
+
+    instance = MagicMock()
+    # simulate thread running once then stopping after max questions reached
+    instance.is_alive.side_effect = [True, False]
+
+    def join_side_effect(timeout=None):
+        stats.questions_answered = 1
+
+    instance.join.side_effect = join_side_effect
+    mock_runner = MagicMock(return_value=instance)
+    monkeypatch.setattr(run, "QuizRunner", mock_runner)
+
+    cfg = MagicMock(
+        quiz_region=Region(1, 2, 3, 4),
+        chat_box=Point(5, 6),
+        response_region=Region(7, 8, 9, 10),
+        option_base=Point(11, 12),
+    )
+    monkeypatch.setattr(run, "Settings", MagicMock(return_value=cfg))
+    monkeypatch.setattr(run, "configure_logger", MagicMock())
+
+    run.main(["--mode", "headless", "--max-questions", "1"])
+
+    instance.stop.assert_called_once()
 


### PR DESCRIPTION
## Summary
- join the quiz runner in headless mode and handle `KeyboardInterrupt` for clean shutdown
- add optional `--max-questions` flag to auto-stop after a set number of questions
- extend tests for join behavior and max-question stopping

## Testing
- `pytest tests/test_run.py -q`
- `python run.py --mode headless --max-questions 1` *(fails: No module named 'pyperclip')*


------
https://chatgpt.com/codex/tasks/task_e_689be78ccb448328b0ab116d541543bb