### PR TITLE
Use openai_model setting in ChatGPT client

### DIFF
--- a/quiz_automation/chatgpt_client.py
+++ b/quiz_automation/chatgpt_client.py
@@ -41,7 +41,7 @@ class ChatGPTClient:
 
     def _completion(self, prompt: str) -> str:
         response = self.client.responses.create(
-            model=settings.model,
+            model=settings.openai_model,
             input=[
                 {"role": "system", "content": settings.openai_system_prompt},
                 {"role": "user", "content": prompt},

--- a/tests/test_chatgpt_client.py
+++ b/tests/test_chatgpt_client.py
@@ -34,7 +34,7 @@ def test_chatgpt_client_parses_json_response(monkeypatch):
 
 
 def test_chatgpt_client_uses_settings(monkeypatch):
-    monkeypatch.setattr(settings, "model", "my-model")
+    monkeypatch.setattr(settings, "openai_model", "my-model")
     monkeypatch.setattr(settings, "openai_system_prompt", "my prompt")
     client = _setup_client(monkeypatch)
     client.ask("Q?")


### PR DESCRIPTION
## Summary
- reference the `openai_model` configuration option in `ChatGPTClient`
- update tests to patch `openai_model` setting

## Testing
- `pytest tests/test_chatgpt_client.py`

------
https://chatgpt.com/codex/tasks/task_e_689c08e4e6f08328ab766360b2578146