### PR TITLE
Add max question limit and graceful shutdown

### DIFF
--- a/quiz_automation/runner.py
+++ b/quiz_automation/runner.py
@@ -30,6 +30,7 @@ class QuizRunner(threading.Thread):
         stats: Stats | None = None,
         gui: QuizGUI | None = None,
         poll_interval: float = 0.5,
+        max_questions: int | None = None,
     ) -> None:
         super().__init__(daemon=True)
         self.quiz_region = quiz_region
@@ -41,6 +42,7 @@ class QuizRunner(threading.Thread):
         self.stats = stats or Stats()
         self.gui = gui
         self.poll_interval = poll_interval
+        self.max_questions = max_questions
 
     def stop(self) -> None:
         """Signal the runner to stop."""
@@ -81,6 +83,12 @@ class QuizRunner(threading.Thread):
                 finally:
                     if self.gui is not None:
                         self.gui.update(self.stats)
+
+                if (
+                    self.max_questions is not None
+                    and self.stats.questions_answered >= self.max_questions
+                ):
+                    self.stop()
 
         t_capture = threading.Thread(target=capture, daemon=True)
         t_worker = threading.Thread(target=worker, daemon=True)

--- a/run.py
+++ b/run.py
@@ -34,6 +34,11 @@ def main(argv: list[str] | None = None) -> None:
         "--config",
         help="Path to a configuration file read by the Settings class",
     )
+    parser.add_argument(
+        "--max-questions",
+        type=int,
+        help="Maximum number of questions to answer before exiting",
+    )
     args = parser.parse_args(argv)
 
     level = getattr(logging, args.log_level.upper(), logging.INFO)
@@ -55,8 +60,14 @@ def main(argv: list[str] | None = None) -> None:
             cfg.response_region,
             options,
             cfg.option_base,
+            max_questions=args.max_questions,
         )
         runner.start()
+        try:
+            runner.join()
+        except KeyboardInterrupt:
+            runner.stop()
+            runner.join()
 
 
 if __name__ == "__main__":

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -46,3 +46,37 @@ def test_runner_triggers_full_flow(monkeypatch):
     runner.join(timeout=1)
 
     assert calls == {"screenshot": 1, "paste": 1, "read": 1, "click": 1}
+
+
+def test_runner_respects_max_questions(monkeypatch):
+    monkeypatch.setattr(automation.pyautogui, "screenshot", lambda region=None: "img")
+    monkeypatch.setattr(automation.pyautogui, "moveTo", lambda x, y: None)
+    monkeypatch.setattr(automation.pytesseract, "image_to_string", lambda img: "A")
+    monkeypatch.setattr(automation, "send_to_chatgpt", lambda img, box: None)
+    monkeypatch.setattr(
+        automation, "read_chatgpt_response", lambda region, timeout=20.0, poll_interval=0.5: "Answer A"
+    )
+    monkeypatch.setattr(automation, "click_option", lambda base, idx, offset=40: None)
+
+    def fake_answer(*args, **kwargs):
+        stats = kwargs.get("stats")
+        if stats is not None:
+            stats.record(0.1, 1)
+        return "A"
+
+    monkeypatch.setattr(automation, "answer_question_via_chatgpt", fake_answer)
+    monkeypatch.setattr("quiz_automation.runner.answer_question_via_chatgpt", fake_answer)
+
+    runner = QuizRunner(
+        Region(0, 0, 10, 10),
+        Point(0, 0),
+        Region(0, 0, 10, 10),
+        ["A", "B"],
+        Point(0, 0),
+        max_questions=1,
+    )
+
+    runner.start()
+    runner.join(timeout=1)
+
+    assert runner.stats.questions_answered == 1


### PR DESCRIPTION
## Summary
- allow setting a `--max-questions` limit from the CLI and forward to `QuizRunner`
- make `QuizRunner` stop once the maximum question count is reached
- ensure the runner thread joins and handles `KeyboardInterrupt`
- cover new behavior with tests

## Testing
- `pytest tests/test_run.py tests/test_runner.py`
- `pytest` *(fails: ValidationError and other test failures)*
- `python run.py --mode headless --max-questions 1` *(fails: failed to copy image to clipboard)*

------
https://chatgpt.com/codex/tasks/task_e_689c08e590908328bfc561fa576e2338