### PR TITLE
Add model client protocol and backend selection

### DIFF
--- a/quiz_automation/config.py
+++ b/quiz_automation/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic import field_validator
+import re
 
 from .types import Point, Region
 
@@ -24,6 +25,36 @@ class Settings(BaseSettings):
     option_base: Point = Point(100, 520)
 
     model_config = SettingsConfigDict(env_prefix="", extra="ignore")
+
+    @field_validator("quiz_region", "response_region", mode="before")
+    @classmethod
+    def _parse_region(cls, v):
+        if isinstance(v, Region):
+            return v
+        if isinstance(v, str):
+            nums = [int(n) for n in re.findall(r"-?\d+", v)]
+        elif isinstance(v, (list, tuple)):
+            nums = [int(n) for n in v]
+        else:
+            raise TypeError("Invalid region value")
+        if len(nums) != 4:
+            raise ValueError("Region requires four integers")
+        return Region(*nums)
+
+    @field_validator("chat_box", "option_base", mode="before")
+    @classmethod
+    def _parse_point(cls, v):
+        if isinstance(v, Point):
+            return v
+        if isinstance(v, str):
+            nums = [int(n) for n in re.findall(r"-?\d+", v)]
+        elif isinstance(v, (list, tuple)):
+            nums = [int(n) for n in v]
+        else:
+            raise TypeError("Invalid point value")
+        if len(nums) != 2:
+            raise ValueError("Point requires two integers")
+        return Point(*nums)
 
 
 

--- a/quiz_automation/model_client.py
+++ b/quiz_automation/model_client.py
@@ -3,15 +3,17 @@ from __future__ import annotations
 
 import re
 from collections import Counter
-from typing import List
+from typing import Sequence
+
+from .model_protocol import ModelClientProtocol
 
 
-class LocalModelClient:
+class LocalModelClient(ModelClientProtocol):
     """Pick the option sharing the most words with the question."""
 
-    def ask(self, question: str, options: List[str]) -> str:
+    def ask(self, question: str, options: Sequence[str]) -> str:
         question_words = Counter(re.findall(r"\w+", question.lower()))
-        scores: List[int] = []
+        scores: list[int] = []
         for opt in options:
             opt_words = Counter(re.findall(r"\w+", opt.lower()))
             scores.append(sum((question_words & opt_words).values()))

--- a/quiz_automation/model_protocol.py
+++ b/quiz_automation/model_protocol.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+"""Protocol for model clients that answer quiz questions."""
+
+from typing import Protocol, Sequence, runtime_checkable
+
+
+@runtime_checkable
+class ModelClientProtocol(Protocol):
+    """Client capable of answering multiple choice questions."""
+
+    def ask(self, question: str, options: Sequence[str]) -> str:
+        """Return the chosen option letter for *question*.
+
+        Implementations should return a single uppercase letter corresponding
+        to the index of the selected option (``"A"`` for the first option,
+        ``"B"`` for the second, etc.).
+        """
+        ...

--- a/run.py
+++ b/run.py
@@ -8,6 +8,8 @@ from quiz_automation import QuizGUI
 from quiz_automation.runner import QuizRunner
 from quiz_automation.config import Settings
 from quiz_automation.logger import configure_logger
+from quiz_automation.chatgpt_client import ChatGPTClient
+from quiz_automation.model_client import LocalModelClient
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -24,6 +26,12 @@ def main(argv: list[str] | None = None) -> None:
         choices=["gui", "headless"],
         default="gui",
         help="Choose whether to launch the GUI or run in headless mode.",
+    )
+    parser.add_argument(
+        "--backend",
+        choices=["chatgpt", "local"],
+        default="chatgpt",
+        help="Model backend to use for answering questions.",
     )
     parser.add_argument(
         "--log-level",
@@ -49,12 +57,17 @@ def main(argv: list[str] | None = None) -> None:
     else:
         cfg = Settings(_env_file=args.config) if args.config else Settings()
         options = list("ABCD")
+        if args.backend == "chatgpt":
+            client = ChatGPTClient()
+        else:
+            client = LocalModelClient()
         runner = QuizRunner(
             cfg.quiz_region,
             cfg.chat_box,
             cfg.response_region,
             options,
             cfg.option_base,
+            model=client,
         )
         runner.start()
 

--- a/tests/test_automation.py
+++ b/tests/test_automation.py
@@ -56,8 +56,7 @@ def test_read_chatgpt_response_default_poll_interval(monkeypatch):
         "time",
         types.SimpleNamespace(time=lambda: 0, sleep=lambda s: sleeps.append(s)),
     )
-
-
+    text = automation.read_chatgpt_response(Region(0, 0, 1, 1))
     assert text == "hello"
     assert sleeps == [0.5]
 
@@ -92,7 +91,7 @@ def test_read_chatgpt_response_custom_poll_interval(monkeypatch):
         types.SimpleNamespace(time=lambda: 0, sleep=lambda s: sleeps.append(s)),
     )
 
-    text = automation.read_chatgpt_response((0, 0, 1, 1), poll_interval=0.1)
+    text = automation.read_chatgpt_response(Region(0, 0, 1, 1), poll_interval=0.1)
     assert text == "hello"
     assert sleeps == [0.1]
 

--- a/tests/test_chatgpt_client.py
+++ b/tests/test_chatgpt_client.py
@@ -30,14 +30,14 @@ def _setup_client(monkeypatch) -> ChatGPTClient:
 
 def test_chatgpt_client_parses_json_response(monkeypatch):
     client = _setup_client(monkeypatch)
-    assert client.ask("Q?") == "B"
+    assert client.ask("Q?", ["A", "B"]) == "B"
 
 
 def test_chatgpt_client_uses_settings(monkeypatch):
-    monkeypatch.setattr(settings, "model", "my-model")
+    monkeypatch.setattr(settings, "openai_model", "my-model")
     monkeypatch.setattr(settings, "openai_system_prompt", "my prompt")
     client = _setup_client(monkeypatch)
-    client.ask("Q?")
+    client.ask("Q?", ["A", "B"])
     kwargs = DummyOpenAI.last_kwargs
     assert kwargs["model"] == "my-model"
     assert kwargs["input"][0]["content"] == "my prompt"
@@ -55,7 +55,7 @@ def test_chatgpt_client_retries_on_transient_error(monkeypatch):
 
     monkeypatch.setattr(client, "_completion", fake)
     monkeypatch.setattr("quiz_automation.chatgpt_client.time.sleep", lambda s: None)
-    assert client.ask("Q?") == "A"
+    assert client.ask("Q?", ["A", "B"]) == "A"
     assert calls["n"] == 2
 
 
@@ -63,7 +63,7 @@ def test_chatgpt_client_invalid_schema(monkeypatch):
     client = _setup_client(monkeypatch)
     monkeypatch.setattr(client, "_completion", lambda prompt: '{"answer":"Z"}')
     with pytest.raises(RuntimeError):
-        client.ask("Q?")
+        client.ask("Q?", ["A", "B"]) 
 
 
 def test_chatgpt_client_raises_after_transient_errors(monkeypatch):
@@ -75,4 +75,4 @@ def test_chatgpt_client_raises_after_transient_errors(monkeypatch):
     monkeypatch.setattr(client, "_completion", fail)
     monkeypatch.setattr("quiz_automation.chatgpt_client.time.sleep", lambda s: None)
     with pytest.raises(RuntimeError):
-        client.ask("Q?", retries=2)
+        client.ask("Q?", ["A", "B"], retries=2)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,7 +12,6 @@ def test_openai_config_overrides(monkeypatch):
     monkeypatch.setenv("OPENAI_MODEL", "foo")
     monkeypatch.setenv("OPENAI_SYSTEM_PROMPT", "prompt")
     cfg = Settings()
-    assert cfg.model == "foo"
     assert cfg.openai_model == "foo"
     assert cfg.openai_system_prompt == "prompt"
 

--- a/tests/test_model_client.py
+++ b/tests/test_model_client.py
@@ -1,4 +1,22 @@
 from quiz_automation.model_client import LocalModelClient
+from quiz_automation.chatgpt_client import ChatGPTClient
+import quiz_automation.chatgpt_client as chatgpt_client
+from quiz_automation.model_protocol import ModelClientProtocol
+
+
+class DummyOpenAI:
+    """Minimal stand in for the OpenAI client used in tests."""
+
+    def __init__(self, api_key=None):
+        pass
+
+    class responses:  # type: ignore
+        @staticmethod
+        def create(**kwargs):
+            class R:
+                output_text = '{"answer":"B"}'
+
+            return R()
 
 
 def test_model_client_overlap():
@@ -6,3 +24,11 @@ def test_model_client_overlap():
     question = "Which fruit is often used in cherry pie?"
     options = ["Banana", "Cherry", "Pumpkin"]
     assert client.ask(question, options) == "B"
+
+
+def test_chatgpt_client_conforms(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    monkeypatch.setattr(chatgpt_client, "OpenAI", DummyOpenAI)
+    client = ChatGPTClient()
+    assert isinstance(client, ModelClientProtocol)
+    assert client.ask("Q?", ["A", "B"]) == "B"

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,48 +1,45 @@
+from unittest.mock import MagicMock
+
 from quiz_automation.runner import QuizRunner
 from quiz_automation import automation
 from quiz_automation.types import Point, Region
 
 
-def test_runner_triggers_full_flow(monkeypatch):
-    calls = {"screenshot": 0, "paste": 0, "read": 0, "click": 0}
+def test_runner_uses_model_client(monkeypatch):
+    calls = {"screenshot": 0, "click": 0, "ask": 0}
 
     def fake_screenshot(region=None):
         calls["screenshot"] += 1
         return "img"
 
     monkeypatch.setattr(automation.pyautogui, "screenshot", fake_screenshot)
-    monkeypatch.setattr(automation.pyautogui, "moveTo", lambda x, y: None)
-    monkeypatch.setattr(automation.pytesseract, "image_to_string", lambda img: "A")
-
-    def fake_send(img, box):
-        calls["paste"] += 1
-
-    monkeypatch.setattr(automation, "send_to_chatgpt", fake_send)
-
-    def fake_read(region, timeout=20.0, poll_interval=0.5):
-        calls["read"] += 1
-        return "Answer A"
-
-    monkeypatch.setattr(automation, "read_chatgpt_response", fake_read)
+    monkeypatch.setattr(automation.pytesseract, "image_to_string", lambda img: "Q?")
 
     def fake_click(base, idx, offset=40):
         calls["click"] += 1
 
     monkeypatch.setattr(automation, "click_option", fake_click)
 
-    runner = QuizRunner(Region(0, 0, 10, 10), Point(0, 0), Region(0, 0, 10, 10), ["A", "B"], Point(0, 0))
+    model = MagicMock()
 
-    orig = automation.answer_question_via_chatgpt
-
-    def wrapped(*args, **kwargs):
-        result = orig(*args, **kwargs)
+    def fake_ask(question, options):
+        calls["ask"] += 1
         runner.stop()
-        return result
+        return "A"
 
-    monkeypatch.setattr(automation, "answer_question_via_chatgpt", wrapped)
-    monkeypatch.setattr("quiz_automation.runner.answer_question_via_chatgpt", wrapped)
+    model.ask.side_effect = fake_ask
+
+    runner = QuizRunner(
+        Region(0, 0, 10, 10),
+        Point(0, 0),
+        Region(0, 0, 10, 10),
+        ["A", "B"],
+        Point(0, 0),
+        model=model,
+    )
 
     runner.start()
     runner.join(timeout=1)
 
-    assert calls == {"screenshot": 1, "paste": 1, "read": 1, "click": 1}
+    assert calls == {"screenshot": 1, "click": 1, "ask": 1}
+    model.ask.assert_called_once_with("Q?", ["A", "B"])


### PR DESCRIPTION
## Summary
- Define `ModelClientProtocol` for quiz answering models
- Implement protocol in ChatGPT and local clients
- Support selecting ChatGPT or local model backend via CLI and runner
- Extend configuration parsing for regions/points and add comprehensive tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c08e616ec832898c24d765567df9d