### PR TITLE
Import Region type in utils

### DIFF
--- a/quiz_automation/utils.py
+++ b/quiz_automation/utils.py
@@ -9,6 +9,10 @@ import logging
 import subprocess
 import sys
 
+from typing import Any
+
+from .types import Region
+
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- import Region type in utils helper

## Testing
- `mypy quiz_automation/utils.py --ignore-missing-imports` *(fails: Item "None" of "IO[bytes] | None" has no attribute "__enter__"; Item "None" of "IO[bytes] | None" has no attribute "__exit__"; Argument 1 to "Clicker" has incompatible type "Point"; expected "tuple[int, int]")*

------
https://chatgpt.com/codex/tasks/task_e_689c08e6f8a0832890ea1d12acb3fab6