### PR TITLE
Propagate temperature setting to OpenAI responses

### DIFF
--- a/quiz_automation/chatgpt_client.py
+++ b/quiz_automation/chatgpt_client.py
@@ -43,6 +43,7 @@ class ChatGPTClient(ModelClientProtocol):
     def _completion(self, prompt: str) -> str:
         response = self.client.responses.create(
             model=settings.openai_model,
+            temperature=settings.temperature,
             input=[
                 {"role": "system", "content": settings.openai_system_prompt},
                 {"role": "user", "content": prompt},

--- a/tests/test_chatgpt_client.py
+++ b/tests/test_chatgpt_client.py
@@ -36,12 +36,14 @@ def test_chatgpt_client_parses_json_response(monkeypatch):
 def test_chatgpt_client_uses_settings(monkeypatch):
     monkeypatch.setattr(settings, "openai_model", "my-model")
     monkeypatch.setattr(settings, "openai_system_prompt", "my prompt")
+    monkeypatch.setattr(settings, "temperature", 0.42)
     client = _setup_client(monkeypatch)
     client.ask("Q?", ["Opt1", "Opt2"])
     kwargs = DummyOpenAI.last_kwargs
     assert kwargs["model"] == "my-model"
     assert kwargs["input"][0]["content"] == "my prompt"
     assert "Opt2" in kwargs["input"][1]["content"]
+    assert kwargs["temperature"] == 0.42
 
 
 def test_chatgpt_client_retries_on_transient_error(monkeypatch):


### PR DESCRIPTION
## Summary
- pass configured temperature to `client.responses.create`
- test that ChatGPTClient forwards `settings.temperature`

## Testing
- `pytest tests/test_chatgpt_client.py`


------
https://chatgpt.com/codex/tasks/task_e_689c2e30a46483288dd6a968cae07505