### PR TITLE
Refactor question answering to use OCR for model clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ quiz-automation --mode headless --log-level DEBUG --config settings.env
 
 ## CLI example
 ```python
-from quiz_automation import answer_question_via_chatgpt, Stats
+from quiz_automation import answer_question, Stats
 from quiz_automation.config import Settings
 import pyautogui
 
@@ -81,7 +81,7 @@ cfg = Settings()
 options = list("ABCD")
 
 img = pyautogui.screenshot(cfg.quiz_region)
-letter = answer_question_via_chatgpt(
+letter = answer_question(
     img,
     cfg.chat_box,
     cfg.response_region,

--- a/quiz_automation/__init__.py
+++ b/quiz_automation/__init__.py
@@ -7,7 +7,7 @@ area is provided here.
 """
 
 from .automation import (
-    answer_question_via_chatgpt,
+    answer_question,
     click_option,
     read_chatgpt_response,
     send_to_chatgpt,
@@ -19,7 +19,7 @@ from .stats import Stats
 __all__ = [
     "QuizRunner",
     "QuizGUI",
-    "answer_question_via_chatgpt",
+    "answer_question",
     "send_to_chatgpt",
     "read_chatgpt_response",
     "click_option",

--- a/quiz_automation/automation.py
+++ b/quiz_automation/automation.py
@@ -40,6 +40,8 @@ from .logger import get_logger
 from .clicker import Clicker
 from .types import Point, Region
 from .model_client import ModelClientProtocol
+from . import ocr
+from .config import settings
 
 logger = get_logger(__name__)
 
@@ -47,7 +49,7 @@ __all__ = [
     "send_to_chatgpt",
     "read_chatgpt_response",
     "click_option",
-    "answer_question_via_chatgpt",
+    "answer_question",
 ]
 
 
@@ -140,7 +142,7 @@ def click_option(base: Point, index: int, offset: int = 40) -> None:
     Clicker(base, offset).click_option(index)
 
 
-def answer_question_via_chatgpt(
+def answer_question(
     quiz_image: Any,
     chatgpt_box: Point,
     response_region: Region,
@@ -150,12 +152,12 @@ def answer_question_via_chatgpt(
     poll_interval: float = 0.5,
     client: ModelClientProtocol | None = None,
 ) -> str:
-    """Send ``quiz_image`` to ChatGPT and click the model's chosen answer.
+    """Send ``quiz_image`` to a model and click the chosen answer.
 
-    The function blocks until text appears in ``response_region`` or raises a
-    :class:`TimeoutError`.  The returned string is the letter that was clicked.
-    ``stats`` can be supplied to record per-question metrics. ``poll_interval``
-    controls how frequently the ChatGPT response region is polled.
+    When ``client`` is ``None`` the image is pasted into the ChatGPT UI and the
+    response region is polled until an answer appears.  When ``client`` is
+    provided the image is OCR'd using the configured backend and the resulting
+    question and option text are forwarded to ``client.ask``.
     """
 
     start = time.time()
@@ -165,8 +167,21 @@ def answer_question_via_chatgpt(
         matches = re.findall(r"[A-D]", response.upper())
         letter = matches[-1] if matches else ""
     else:
+        ocr_backend = ocr.get_backend(settings.ocr_backend)
+        text = ocr_backend(quiz_image)
+        lines = [l.strip() for l in text.splitlines() if l.strip()]
+        question_lines: list[str] = []
+        option_texts: list[str] = []
+        valid_letters = {o.upper() for o in options}
+        for line in lines:
+            match = re.match(r"([A-Za-z])[).:-]?\s*(.*)", line)
+            if match and match.group(1).upper() in valid_letters:
+                option_texts.append(match.group(2).strip())
+            else:
+                question_lines.append(line)
+        question_text = " ".join(question_lines)
         response = ""
-        letter = client.ask(quiz_image, list(options))
+        letter = client.ask(question_text, option_texts)
 
     try:
         idx = options.index(letter)

--- a/quiz_automation/runner.py
+++ b/quiz_automation/runner.py
@@ -7,7 +7,7 @@ import time
 from typing import Sequence
 
 from . import automation
-from .automation import answer_question_via_chatgpt
+from .automation import answer_question
 from .model_client import ModelClientProtocol
 from .stats import Stats
 from .gui import QuizGUI
@@ -50,7 +50,7 @@ class QuizRunner(threading.Thread):
         self.stop_flag.set()
 
     # The behaviour of this method is tested indirectly via unit tests that
-    # patch :func:`answer_question_via_chatgpt`, so it is excluded from coverage
+    # patch :func:`answer_question`, so it is excluded from coverage
     def run(self) -> None:  # pragma: no cover
         q: queue.Queue = queue.Queue(maxsize=1)
 
@@ -69,7 +69,7 @@ class QuizRunner(threading.Thread):
                 except queue.Empty:
                     continue
                 try:
-                    answer_question_via_chatgpt(
+                    answer_question(
                         img,
                         self.chatgpt_box,
                         self.response_region,

--- a/tests/test_automation.py
+++ b/tests/test_automation.py
@@ -143,7 +143,7 @@ def test_answer_question_fallback_to_first_option(monkeypatch):
 
     monkeypatch.setattr(automation, "click_option", fake_click_option)
 
-    letter = automation.answer_question_via_chatgpt(
+    letter = automation.answer_question(
         "img", Point(0, 0), Region(0, 0, 1, 1), ["A", "B", "C"], Point(0, 0)
     )
 
@@ -152,7 +152,7 @@ def test_answer_question_fallback_to_first_option(monkeypatch):
 
 
 def test_answer_question_custom_poll_interval(monkeypatch):
-    """``answer_question_via_chatgpt`` forwards ``poll_interval``."""
+    """``answer_question`` forwards ``poll_interval``."""
 
     calls: list[float] = []
 
@@ -165,7 +165,7 @@ def test_answer_question_custom_poll_interval(monkeypatch):
     monkeypatch.setattr(automation, "read_chatgpt_response", fake_read)
     monkeypatch.setattr(automation, "click_option", lambda base, idx, offset=40: None)
 
-    letter = automation.answer_question_via_chatgpt(
+    letter = automation.answer_question(
         "img", (0, 0), (0, 0, 1, 1), ["A", "B"], (0, 0), poll_interval=0.2
     )
     assert letter == "A"
@@ -176,9 +176,22 @@ def test_answer_question_with_client(monkeypatch):
     """Providing a model client bypasses ChatGPT UI helpers."""
 
     class DummyClient:
+        def __init__(self):
+            self.calls: list[tuple[str, list[str]]] = []
+
         def ask(self, question, options):
+            self.calls.append((question, options))
             return "C"
 
+    def fake_get_backend(name):
+        assert name is None
+
+        def backend(img):
+            return "What?\nA foo\nB bar\nC baz"
+
+        return backend
+
+    monkeypatch.setattr(automation.ocr, "get_backend", fake_get_backend)
     monkeypatch.setattr(
         automation,
         "send_to_chatgpt",
@@ -192,10 +205,12 @@ def test_answer_question_with_client(monkeypatch):
     clicks: list[int] = []
     monkeypatch.setattr(automation, "click_option", lambda base, idx, offset=40: clicks.append(idx))
 
-    letter = automation.answer_question_via_chatgpt(
-        "question", Point(0, 0), Region(0, 0, 1, 1), ["A", "B", "C"], Point(0, 0), client=DummyClient()
+    client = DummyClient()
+    letter = automation.answer_question(
+        "question", Point(0, 0), Region(0, 0, 1, 1), ["A", "B", "C"], Point(0, 0), client=client
     )
 
     assert letter == "C"
     assert clicks == [2]
+    assert client.calls == [("What?", ["foo", "bar", "baz"])]
 

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -31,7 +31,7 @@ def test_automation_logs_message(monkeypatch, caplog):
     )
     monkeypatch.setattr(automation, "click_option", lambda base, idx, offset=40: None)
 
-    letter = automation.answer_question_via_chatgpt(
+    letter = automation.answer_question(
         "img", Point(0, 0), Region(0, 0, 10, 10), ["A", "B"], Point(0, 0)
     )
     assert letter == "B"

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -32,15 +32,15 @@ def test_runner_triggers_full_flow(monkeypatch):
 
     runner = QuizRunner(Region(0, 0, 10, 10), Point(0, 0), Region(0, 0, 10, 10), ["A", "B"], Point(0, 0))
 
-    orig = automation.answer_question_via_chatgpt
+    orig = automation.answer_question
 
     def wrapped(*args, **kwargs):
         result = orig(*args, **kwargs)
         runner.stop()
         return result
 
-    monkeypatch.setattr(automation, "answer_question_via_chatgpt", wrapped)
-    monkeypatch.setattr("quiz_automation.runner.answer_question_via_chatgpt", wrapped)
+    monkeypatch.setattr(automation, "answer_question", wrapped)
+    monkeypatch.setattr("quiz_automation.runner.answer_question", wrapped)
 
     runner.start()
     runner.join(timeout=1)


### PR DESCRIPTION
## Summary
- Rename `answer_question_via_chatgpt` to backend-agnostic `answer_question`
- Use configured OCR backend to extract text when a model client is provided
- Add test verifying OCR text is passed to client

## Testing
- `pytest tests/test_automation.py tests/test_logger.py tests/test_runner.py -q`
- `pytest -q` *(fails: IndentationError in tests/test_run.py)*

------
https://chatgpt.com/codex/tasks/task_e_689c2e2fbc208328be85695ade8b53e1