### PR TITLE
Add backend selection flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,16 @@ quiz-automation --mode gui
 
 # custom config and debug logging
 quiz-automation --mode headless --log-level DEBUG --config settings.env
+
+# offline mode with the built-in heuristic model
+quiz-automation --mode headless --backend local
 ```
 
 `--log-level` sets the logging verbosity (e.g., ``DEBUG``, ``INFO``) and
 `--config` points to a ``.env``-style file loaded before instantiating the
-``Settings`` class.
+``Settings`` class. Use ``--backend`` to choose the model backend: ``chatgpt``
+relies on the OpenAI API while ``local`` uses a simple heuristic and requires
+no network access. The default is ``chatgpt``.
 
 ## CLI example
 ```python

--- a/run.py
+++ b/run.py
@@ -8,6 +8,9 @@ from quiz_automation import QuizGUI
 from quiz_automation.runner import QuizRunner
 from quiz_automation.config import Settings
 from quiz_automation.logger import configure_logger
+from quiz_automation.chatgpt_client import ChatGPTClient
+from quiz_automation.model_client import LocalModelClient
+from quiz_automation.stats import Stats
 
 
 
@@ -36,7 +39,15 @@ def main(argv: list[str] | None = None) -> None:
         help="Path to a configuration file read by the Settings class",
     )
     parser.add_argument(
-
+        "--max-questions",
+        type=int,
+        help="Stop after answering this many questions",
+    )
+    parser.add_argument(
+        "--backend",
+        choices=["chatgpt", "local"],
+        default="chatgpt",
+        help="Model backend to use for answering questions",
     )
     args = parser.parse_args(argv)
 
@@ -53,6 +64,11 @@ def main(argv: list[str] | None = None) -> None:
     else:
         cfg = Settings(_env_file=args.config) if args.config else Settings()
         options = list("ABCD")
+        stats = Stats()
+        if args.backend == "local":
+            client = LocalModelClient()
+        else:
+            client = ChatGPTClient()
 
         runner = QuizRunner(
             cfg.quiz_region,
@@ -60,7 +76,8 @@ def main(argv: list[str] | None = None) -> None:
             cfg.response_region,
             options,
             cfg.option_base,
-
+            model_client=client,
+            stats=stats,
         )
         runner.start()
         try:


### PR DESCRIPTION
## Summary
- Add `--backend` option to choose between ChatGPT and local model backends
- Instantiate selected model client and pass stats to `QuizRunner`
- Document backend flag in README with usage example

## Testing
- `pytest tests/test_chatgpt_client.py::test_chatgpt_client_parses_json_response -q`
- `pytest tests/test_run.py::test_headless_invokes_quiz_runner -q` *(fails: IndentationError in tests/test_run.py)*

------
https://chatgpt.com/codex/tasks/task_e_689c896d94748328afcbba807e33a866