### PR TITLE
Add model backend selection in CLI

### DIFF
--- a/run.py
+++ b/run.py
@@ -10,6 +10,8 @@ from quiz_automation.config import Settings
 from quiz_automation.logger import configure_logger
 
 from quiz_automation.stats import Stats
+from quiz_automation.chatgpt_client import ChatGPTClient
+from quiz_automation.model_client import LocalModelClient
 
 
 
@@ -64,7 +66,9 @@ def main(argv: list[str] | None = None) -> None:
         cfg = Settings(_env_file=args.config) if args.config else Settings()
         options = list("ABCD")
         stats = Stats()
-
+        model_client = (
+            ChatGPTClient() if args.backend == "chatgpt" else LocalModelClient()
+        )
 
         runner = QuizRunner(
             cfg.quiz_region,
@@ -72,7 +76,7 @@ def main(argv: list[str] | None = None) -> None:
             cfg.response_region,
             options,
             cfg.option_base,
-
+            model_client=model_client,
             stats=stats,
         )
         runner.start()


### PR DESCRIPTION
## Summary
- allow choosing ChatGPT or local model backend via --backend
- pass model client and stats to QuizRunner and stop after --max-questions

## Testing
- `pytest -q` (fails: IndentationError in tests/test_run.py)
- `python run.py --mode headless --backend local --max-questions 0` (fails: pytesseract not available)


------
https://chatgpt.com/codex/tasks/task_e_689cf57281f08328814ad2d97d5fa0f9