### PR TITLE
Add CLI run tests for backend selection and max questions

### DIFF
--- a/run.py
+++ b/run.py
@@ -10,6 +10,8 @@ from quiz_automation.config import Settings
 from quiz_automation.logger import configure_logger
 
 from quiz_automation.stats import Stats
+from quiz_automation.chatgpt_client import ChatGPTClient
+from quiz_automation.model_client import LocalModelClient
 
 
 
@@ -64,7 +66,7 @@ def main(argv: list[str] | None = None) -> None:
         cfg = Settings(_env_file=args.config) if args.config else Settings()
         options = list("ABCD")
         stats = Stats()
-
+        model_client = ChatGPTClient() if args.backend == "chatgpt" else LocalModelClient()
 
         runner = QuizRunner(
             cfg.quiz_region,
@@ -72,7 +74,7 @@ def main(argv: list[str] | None = None) -> None:
             cfg.response_region,
             options,
             cfg.option_base,
-
+            model_client=model_client,
             stats=stats,
         )
         runner.start()

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,15 +1,55 @@
+from unittest.mock import MagicMock, patch
 
+import pytest
 
 import run
 from quiz_automation.types import Point, Region
 
 
-
+@pytest.mark.parametrize("backend, client_attr", [
+    ("chatgpt", "ChatGPTClient"),
+    ("local", "LocalModelClient"),
+])
+def test_main_invokes_runner_with_client_and_stops(backend: str, client_attr: str) -> None:
     cfg = MagicMock(
         quiz_region=Region(1, 2, 3, 4),
         chat_box=Point(5, 6),
         response_region=Region(7, 8, 9, 10),
         option_base=Point(11, 12),
     )
+    mock_stats = MagicMock()
+    mock_stats.questions_answered = 5
 
+    with patch("run.Settings", return_value=cfg), \
+        patch("run.Stats", return_value=mock_stats), \
+        patch(f"run.{client_attr}") as mock_client_cls, \
+        patch("run.QuizRunner") as mock_runner:
 
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+
+        runner_instance = MagicMock()
+        runner_instance.is_alive.side_effect = [True, False]
+        mock_runner.return_value = runner_instance
+
+        run.main([
+            "--mode",
+            "headless",
+            "--backend",
+            backend,
+            "--max-questions",
+            "5",
+        ])
+
+        mock_client_cls.assert_called_once_with()
+        mock_runner.assert_called_once_with(
+            cfg.quiz_region,
+            cfg.chat_box,
+            cfg.response_region,
+            list("ABCD"),
+            cfg.option_base,
+            model_client=mock_client,
+            stats=mock_stats,
+        )
+        runner_instance.start.assert_called_once()
+        runner_instance.stop.assert_called_once()


### PR DESCRIPTION
## Summary
- Support selecting ChatGPT or local model clients in CLI and pass them to `QuizRunner`
- Add tests covering `run.main` backend handling and question limit stopping

## Testing
- `pytest tests/test_run.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689d3f3d1b388328b06a643b8a87546a