### PR TITLE
Add Sphinx documentation and docs deployment workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,29 @@
+name: docs
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          pip install -e .
+          pip install sphinx
+      - name: Build documentation
+        run: sphinx-build -b html docs docs/_build/html
+      - name: Deploy to GitHub Pages
+        if: github.ref == 'refs/heads/main'
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/_build/html
+

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 *.pyc
 .venv/
 quiz_log.db
+docs/_build/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,36 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+import os
+import sys
+sys.path.insert(0, os.path.abspath('..'))
+
+project = 'basic-ai-auto-assistant'
+copyright = '2025, Project Contributors'
+author = 'Project Contributors'
+
+version = '0.1'
+release = '0.1'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    'sphinx.ext.autodoc',
+]
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'alabaster'
+html_static_path = ['_static']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,14 @@
+.. basic-ai-auto-assistant documentation master file, created by
+   sphinx-quickstart on Thu Aug 14 06:03:22 2025.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+basic-ai-auto-assistant documentation
+=====================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   modules
+

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1,0 +1,7 @@
+quiz_automation
+===============
+
+.. toctree::
+   :maxdepth: 4
+
+   quiz_automation

--- a/docs/quiz_automation.rst
+++ b/docs/quiz_automation.rst
@@ -1,0 +1,133 @@
+quiz\_automation package
+========================
+
+Submodules
+----------
+
+quiz\_automation.automation module
+----------------------------------
+
+.. automodule:: quiz_automation.automation
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+quiz\_automation.chatgpt\_client module
+---------------------------------------
+
+.. automodule:: quiz_automation.chatgpt_client
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+quiz\_automation.clicker module
+-------------------------------
+
+.. automodule:: quiz_automation.clicker
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+quiz\_automation.config module
+------------------------------
+
+.. automodule:: quiz_automation.config
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+quiz\_automation.cv\_expert module
+----------------------------------
+
+.. automodule:: quiz_automation.cv_expert
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+quiz\_automation.gui module
+---------------------------
+
+.. automodule:: quiz_automation.gui
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+quiz\_automation.logger module
+------------------------------
+
+.. automodule:: quiz_automation.logger
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+quiz\_automation.model\_client module
+-------------------------------------
+
+.. automodule:: quiz_automation.model_client
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+quiz\_automation.ocr module
+---------------------------
+
+.. automodule:: quiz_automation.ocr
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+quiz\_automation.region\_selector module
+----------------------------------------
+
+.. automodule:: quiz_automation.region_selector
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+quiz\_automation.runner module
+------------------------------
+
+.. automodule:: quiz_automation.runner
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+quiz\_automation.stats module
+-----------------------------
+
+.. automodule:: quiz_automation.stats
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+quiz\_automation.types module
+-----------------------------
+
+.. automodule:: quiz_automation.types
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+quiz\_automation.utils module
+-----------------------------
+
+.. automodule:: quiz_automation.utils
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+quiz\_automation.watcher module
+-------------------------------
+
+.. automodule:: quiz_automation.watcher
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+Module contents
+---------------
+
+.. automodule:: quiz_automation
+   :members:
+   :show-inheritance:
+   :undoc-members:


### PR DESCRIPTION
## Summary
- Initialize Sphinx docs with autodoc for `quiz_automation` modules
- Configure path and build settings in `conf.py`
- Add GitHub Actions workflow to build and deploy docs to `gh-pages`

## Testing
- `sphinx-build -b html docs docs/_build/html`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d7bc34e4c8328814dc1dce8e8967d