### PR TITLE
ci: test against multiple Python versions

### DIFF
--- a/.github/branch-protection.yml
+++ b/.github/branch-protection.yml
@@ -1,0 +1,5 @@
+# Branch protection rules for required status checks
+required_status_checks:
+  - test (3.10)
+  - test (3.11)
+  - test (3.12)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,18 @@ jobs:
   test:
     name: test
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: |
+            pyproject.toml
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
- expand CI matrix to Python 3.10–3.12 and cache dependencies per version
- add branch protection rules requiring each CI job

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d71de51748328a024be8184b9e541