### PR TITLE
Enable coverage reporting in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .
-          pip install pytest
+          pip install pytest pytest-cov
       - name: Run tests
-        run: pytest
+        run: pytest --cov=quiz_automation --cov-report=xml
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage.xml

--- a/README.md
+++ b/README.md
@@ -94,10 +94,18 @@ runner.start()             # capture + worker threads
 The window updates with question count, average response time, tokens, and errors as the runner progresses.
 
 ## Tests
-Run the test suite with:
+Run the test suite with coverage:
 ```bash
-pytest
+pytest --cov=quiz_automation
 ```
+The CI workflow emits `coverage.xml`, which can be uploaded to a service like [Codecov](https://about.codecov.io/) or [Coveralls](https://coveralls.io/) for a coverage badge. After enabling a service, add its badge to the top of the README, for example with Codecov:
+
+```markdown
+[![codecov](https://codecov.io/gh/OWNER/basic-ai-auto-assistant/branch/main/graph/badge.svg)](https://codecov.io/gh/OWNER/basic-ai-auto-assistant)
+```
+
+Replace `OWNER` with your GitHub username.
+
 Some tests rely on optional packages such as `numpy` and will be skipped when
 those dependencies are missing. Install the extras for full coverage:
 


### PR DESCRIPTION
## Summary
- collect coverage in CI with `pytest --cov` and upload `coverage.xml` as an artifact
- document running tests with coverage and adding a Codecov badge

## Testing
- `pytest --cov=quiz_automation --cov-report=xml`


------
https://chatgpt.com/codex/tasks/task_e_689d71e058dc8328acca84e31a729fc0