### PR TITLE
Validate region before saving in RegionSelector

### DIFF
--- a/quiz_automation/region_selector.py
+++ b/quiz_automation/region_selector.py
@@ -14,6 +14,7 @@ from typing import Dict
 import json
 
 from .types import Region
+from .utils import validate_region
 
 try:  # pragma: no cover - optional dependency
     import pyautogui  # type: ignore
@@ -72,6 +73,11 @@ class RegionSelector:
         input("Move mouse to bottom right and press Enter")
         x2, y2 = pyautogui.position()
         region = Region(x1, y1, x2 - x1, y2 - y1)
+
+        try:
+            validate_region(region)
+        except ValueError as exc:
+            raise ValueError(f"Invalid region selected: {exc}") from exc
 
         self._regions[name] = region
         try:

--- a/tests/test_region_selector.py
+++ b/tests/test_region_selector.py
@@ -33,3 +33,15 @@ def test_region_selector_corrupted_file(tmp_path, content):
     selector = rs_mod.RegionSelector(path)
     with pytest.raises(KeyError):
         selector.load("quiz")
+
+
+def test_region_selector_invalid_region(tmp_path, monkeypatch):
+    path = tmp_path / "coords.json"
+    selector = rs_mod.RegionSelector(path)
+    positions = iter([(5, 5), (1, 1)])
+    monkeypatch.setattr("builtins.input", lambda prompt="": None)
+    monkeypatch.setattr(rs_mod.pyautogui, "position", lambda: next(positions))
+    with pytest.raises(ValueError):
+        selector.select("quiz")
+    assert "quiz" not in selector._regions
+    assert not path.exists()


### PR DESCRIPTION
## Summary
- ensure RegionSelector.validate() checks region dimensions before persistence
- add test for invalid region selection

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689fc7b9aeb08328945fcdc4ce96a655