### PR TITLE
Handle out-of-range quiz answers

### DIFF
--- a/quiz_automation/automation.py
+++ b/quiz_automation/automation.py
@@ -181,7 +181,7 @@ def answer_question(
                 question_lines.append(line)
         question_text = " ".join(question_lines)
         response = ""
-        letter = client.ask(question_text, option_texts)
+        letter = client.ask(question_text, option_texts).upper()
 
     try:
         idx = options.index(letter)
@@ -189,7 +189,7 @@ def answer_question(
         # Fall back to alphabetical ordering; ensures a valid index even if the
         # model returns an unexpected string such as "E".
         letter = letter or "A"
-        idx = max(0, ord(letter) - ord("A"))
+        idx = max(0, min(len(options) - 1, ord(letter) - ord("A")))
 
     click_option(option_base, idx)
     logger.info("ChatGPT chose %s", letter)


### PR DESCRIPTION
## Summary
- Normalize model responses by uppercasing answer letter
- Clamp computed option index to available choices

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fc7bd302083289ac731934d6087f9