### PR TITLE
Add Dockerfile for containerized usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir -e .[full]
+CMD ["python", "run.py"]

--- a/README.md
+++ b/README.md
@@ -141,3 +141,17 @@ those dependencies are missing. Install the extras for full coverage:
 ```bash
 pip install -e .[full]
 ```
+
+## Docker
+
+Build the image:
+
+```bash
+docker build -t basic-ai-auto-assistant .
+```
+
+Run the container:
+
+```bash
+docker run --rm basic-ai-auto-assistant
+```


### PR DESCRIPTION
## Summary
- provide Dockerfile based on `python:3.11-slim` that installs project with extras
- document image build and run commands in the README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689fd941fc4c8328bcc08b605f12bfa9