### PR TITLE
chore: add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "project-maintainers"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "project-maintainers"


### PR DESCRIPTION
## Summary
- add dependabot config for weekly pip and GitHub Actions updates
- set project-maintainers as reviewers for automated PRs

## Testing
- `pre-commit run --files .github/dependabot.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fd93df5288328a559b4e9655564c2