### PR TITLE
Add thread-safe time/token averages for quiz stats

### DIFF
--- a/quiz_automation/stats.py
+++ b/quiz_automation/stats.py
@@ -27,6 +27,8 @@ class Stats:
         """Record timing and token usage for a successful question."""
         with self._lock:
             self.questions_answered += 1
+            self.total_time += duration
+            self.total_tokens += tokens
 
 
     def record_error(self) -> None:
@@ -38,9 +40,14 @@ class Stats:
     def average_time(self) -> float:
         """Return the average time taken per question."""
         with self._lock:
-
+            if self.questions_answered == 0:
+                return 0.0
+            return self.total_time / self.questions_answered
 
     @property
     def average_tokens(self) -> float:
         """Return the average tokens used per question."""
         with self._lock:
+            if self.questions_answered == 0:
+                return 0.0
+            return self.total_tokens / self.questions_answered


### PR DESCRIPTION
## Summary
- accumulate total time and tokens when recording question stats
- implement average_time and average_tokens helpers with zero-division guard

## Testing
- `pytest tests/test_stats.py`

------
https://chatgpt.com/codex/tasks/task_e_68a2df092510832893d0f1a59ca6cb53