### PR TITLE
Add session logging for quiz runs

### DIFF
--- a/quiz_automation/runner.py
+++ b/quiz_automation/runner.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import queue
 import threading
 import time
-from typing import Sequence
+from typing import Sequence, TextIO
 
 from . import automation
 from .automation import answer_question
@@ -33,6 +33,7 @@ class QuizRunner(threading.Thread):
         stats: Stats | None = None,
         gui: QuizGUI | None = None,
         poll_interval: float = 0.5,
+        session_log: TextIO | None = None,
     ) -> None:
         """Initialise the runner thread."""
         super().__init__(daemon=True)
@@ -46,6 +47,7 @@ class QuizRunner(threading.Thread):
         self.stats = stats or Stats()
         self.gui = gui
         self.poll_interval = poll_interval
+        self.session_log = session_log
 
     def stop(self) -> None:
         """Signal the runner to stop."""
@@ -81,6 +83,7 @@ class QuizRunner(threading.Thread):
                         stats=self.stats,
                         poll_interval=self.poll_interval,
                         client=self.model_client,
+                        session_log=self.session_log,
                     )
                 except Exception:
                     logger.exception("Error while answering question")


### PR DESCRIPTION
## Summary
- add `--session-log` CLI flag to enable JSONL session logging
- write per-question metadata from `answer_question` when session log provided
- route session log handle through `QuizRunner` and CLI, and ensure runner exits after max questions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2e8a0c4788328a62c4778f45362ca