### PR TITLE
Add pause and resume controls to quiz runner

### DIFF
--- a/run.py
+++ b/run.py
@@ -93,7 +93,7 @@ def main(argv: list[str] | None = None) -> None:
                     if not runner.is_alive():
                         break
                     if (
-                        args.max_questions is not None
+                        args.max_questions
                         and stats.questions_answered >= args.max_questions
                     ):
                         runner.stop()
@@ -133,7 +133,7 @@ def main(argv: list[str] | None = None) -> None:
                 if not runner.is_alive():
                     break
                 if (
-                    args.max_questions is not None
+                    args.max_questions
                     and stats.questions_answered >= args.max_questions
                 ):
                     runner.stop()

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,0 +1,51 @@
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+# Provide lightweight stand-ins for optional dependencies so importing the
+# package does not require the real libraries.
+sys.modules.setdefault(
+    "pydantic",
+    SimpleNamespace(
+        BaseModel=object,
+        ValidationError=Exception,
+        field_validator=lambda *a, **k: (lambda f: f),
+    ),
+)
+sys.modules.setdefault(
+    "pydantic_settings",
+    SimpleNamespace(BaseSettings=object, SettingsConfigDict=dict),
+)
+
+from quiz_automation.gui import QuizGUI
+
+
+def test_gui_buttons_trigger_runner_methods():
+    gui = QuizGUI()
+    calls = []
+
+    class DummyRunner:
+        def pause(self):
+            calls.append("pause")
+
+        def resume(self):
+            calls.append("resume")
+
+        def stop(self):
+            calls.append("stop")
+
+    runner = DummyRunner()
+    gui.connect_runner(runner)
+
+    # Simulate button presses; fall back to direct emitters when Qt is absent
+    if getattr(gui, "_pause_btn", None) is not None:
+        gui._pause_btn.click()
+        gui._resume_btn.click()
+        gui._stop_btn.click()
+    else:
+        gui._emit_pause()
+        gui._emit_resume()
+        gui._emit_stop()
+
+    assert calls == ["pause", "resume", "stop"]


### PR DESCRIPTION
## Summary
- Add Pause, Resume, and Stop buttons to QuizGUI and expose callbacks for runner control
- Implement pause/resume logic in QuizRunner and wire GUI signals to the runner
- Treat zero `--max-questions` as unlimited to avoid duplicate stops
- Test GUI buttons invoke appropriate runner methods

## Testing
- `pytest tests/test_gui.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2e8a583e083288d4e0117e0d2b19e