### PR TITLE
Refactor watcher to use mss module

### DIFF
--- a/quiz_automation/watcher.py
+++ b/quiz_automation/watcher.py
@@ -15,7 +15,7 @@ from .utils import hash_text
 logger = logging.getLogger(__name__)
 
 try:  # pragma: no cover - optional dependency
-    from mss import mss
+    import mss
 except Exception:  # pragma: no cover
     mss = None  # type: ignore
 


### PR DESCRIPTION
## Summary
- import the `mss` module instead of `from mss import mss`
- `_mss` now returns the module and `capture` uses `mss_module.mss().grab`

## Testing
- `pytest tests/test_watcher.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a35b64fe848328ac98a08473739163