### PR TITLE
Use keyword region when capturing screenshots

### DIFF
--- a/quiz_automation/automation.py
+++ b/quiz_automation/automation.py
@@ -116,7 +116,7 @@ def read_chatgpt_response(
     validate_region(response_region)
     start = time.time()
     while time.time() - start < timeout:
-        img = pyautogui.screenshot(response_region.as_tuple())
+        img = pyautogui.screenshot(region=response_region.as_tuple())
         text = pytesseract.image_to_string(img).strip()
         if text:
             return text

--- a/quiz_automation/runner.py
+++ b/quiz_automation/runner.py
@@ -76,7 +76,9 @@ class QuizRunner(threading.Thread):
                     time.sleep(0.05)
                     continue
                 if q.empty():
-                    img = automation.pyautogui.screenshot(self.quiz_region.as_tuple())
+                    img = automation.pyautogui.screenshot(
+                        region=self.quiz_region.as_tuple()
+                    )
                     q.put(img)
                 else:
                     time.sleep(0.05)

--- a/tests/test_automation.py
+++ b/tests/test_automation.py
@@ -45,7 +45,11 @@ def test_send_to_chatgpt_copy_failure(monkeypatch):
 def test_read_chatgpt_response_default_poll_interval(monkeypatch):
     """Default ``poll_interval`` of 0.5 seconds is used."""
 
-    monkeypatch.setattr(automation, "pyautogui", types.SimpleNamespace(screenshot=lambda region: "img"))
+    monkeypatch.setattr(
+        automation,
+        "pyautogui",
+        types.SimpleNamespace(screenshot=lambda *, region: "img"),
+    )
     responses = iter(["", " hello "])
     monkeypatch.setattr(
         automation,
@@ -67,7 +71,11 @@ def test_read_chatgpt_response_default_poll_interval(monkeypatch):
 def test_read_chatgpt_response_timeout(monkeypatch):
     """If no text appears before timeout a ``TimeoutError`` is raised."""
 
-    monkeypatch.setattr(automation, "pyautogui", types.SimpleNamespace(screenshot=lambda region: "img"))
+    monkeypatch.setattr(
+        automation,
+        "pyautogui",
+        types.SimpleNamespace(screenshot=lambda *, region: "img"),
+    )
     monkeypatch.setattr(automation, "pytesseract", types.SimpleNamespace(image_to_string=lambda img: ""))
     monkeypatch.setattr(automation, "validate_region", lambda region: None)
     monkeypatch.setattr(automation, "time", types.SimpleNamespace(time=iter([0, 0.6, 1.2]).__next__, sleep=lambda _: None))
@@ -79,7 +87,11 @@ def test_read_chatgpt_response_timeout(monkeypatch):
 def test_read_chatgpt_response_custom_poll_interval(monkeypatch):
     """A custom ``poll_interval`` is honoured."""
 
-    monkeypatch.setattr(automation, "pyautogui", types.SimpleNamespace(screenshot=lambda region: "img"))
+    monkeypatch.setattr(
+        automation,
+        "pyautogui",
+        types.SimpleNamespace(screenshot=lambda *, region: "img"),
+    )
     responses = iter(["", " hello "])
     monkeypatch.setattr(
         automation,

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -10,7 +10,7 @@ from quiz_automation.types import Point, Region
 def test_runner_triggers_full_flow(monkeypatch):
     calls = {"screenshot": 0, "paste": 0, "read": 0, "click": 0}
 
-    def fake_screenshot(region=None):
+    def fake_screenshot(*, region=None):
         calls["screenshot"] += 1
         return "img"
 


### PR DESCRIPTION
## Summary
- use `region=` keyword when taking screenshots in automation helpers
- update `QuizRunner` and tests to pass screenshot region explicitly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a35b6378c88328b9dc1297f5970204