### PR TITLE
Use region keyword in screenshot documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ import pyautogui
 cfg = Settings()
 options = list("ABCD")
 
-img = pyautogui.screenshot(cfg.quiz_region)
+img = pyautogui.screenshot(region=cfg.quiz_region.as_tuple())
 letter = answer_question(
     img,
     cfg.chat_box,


### PR DESCRIPTION
## Summary
- use region keyword in README screenshot example
- ensure pyautogui.screenshot references include `region=`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3690d0e5883289d037f31c4f60702