### PR TITLE
Use dict for screen capture region

### DIFF
--- a/quiz_automation/watcher.py
+++ b/quiz_automation/watcher.py
@@ -54,7 +54,13 @@ class Watcher(threading.Thread):
         except Exception as exc:
             logger.exception("Failed to obtain mss instance")
             raise RuntimeError("Screen capture requires the 'mss' package") from exc
-        return mss_module.mss().grab(self.region.as_tuple())
+        bbox = {
+            "left": self.region.left,
+            "top": self.region.top,
+            "width": self.region.width,
+            "height": self.region.height,
+        }
+        return mss_module.mss().grab(bbox)
 
     def ocr(self, img) -> str:  # pragma: no cover - behaviour provided by backend
         """Return OCR text for *img* using the configured backend."""


### PR DESCRIPTION
## Summary
- Build bounding box dict in `Watcher.capture` before calling `mss.grab`
- Test that screen capture passes a dict to `grab`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a377e75c30832893fb9a9e15681371