### PR TITLE
Validate watcher region

### DIFF
--- a/quiz_automation/watcher.py
+++ b/quiz_automation/watcher.py
@@ -10,7 +10,7 @@ from queue import Queue
 from .config import Settings
 from .ocr import OCRBackend, get_backend
 from .types import Region
-from .utils import hash_text
+from .utils import hash_text, validate_region
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +38,7 @@ class Watcher(threading.Thread):
     ) -> None:
         """Initialize the watcher thread."""
         super().__init__(daemon=True)
+        validate_region(region)
         self.region = region
         self.queue = queue
         self.cfg = cfg

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -1,5 +1,4 @@
 import logging
-import logging
 import time
 from queue import Queue
 
@@ -7,12 +6,12 @@ import pytest
 
 pytest.importorskip("pydantic_settings")
 
+import quiz_automation.ocr as ocr_module
 from quiz_automation import watcher as watcher_module
 from quiz_automation.config import Settings
-import quiz_automation.ocr as ocr_module
 from quiz_automation.ocr import PytesseractOCR
-from quiz_automation.watcher import Watcher
 from quiz_automation.types import Region
+from quiz_automation.watcher import Watcher
 
 
 class DummyMSS:
@@ -22,15 +21,30 @@ class DummyMSS:
 
 def test_default_ocr_backend(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "x")
-    monkeypatch.setattr(watcher_module, "_mss", lambda: type("S", (), {"mss": lambda self=None: DummyMSS()})())
+    monkeypatch.setattr(
+        watcher_module,
+        "_mss",
+        lambda: type("S", (), {"mss": lambda self=None: DummyMSS()})(),
+    )
     cfg = Settings()
     w = Watcher(Region(0, 0, 1, 1), Queue(), cfg)
     assert isinstance(w.ocr_backend, PytesseractOCR)
 
 
+def test_invalid_region_raises_value_error(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    cfg = Settings()
+    with pytest.raises(ValueError):
+        Watcher(Region(0, 0, 0, 1), Queue(), cfg)
+
+
 def test_configured_ocr_backend(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "x")
-    monkeypatch.setattr(watcher_module, "_mss", lambda: type("S", (), {"mss": lambda self=None: DummyMSS()})())
+    monkeypatch.setattr(
+        watcher_module,
+        "_mss",
+        lambda: type("S", (), {"mss": lambda self=None: DummyMSS()})(),
+    )
     monkeypatch.setattr(ocr_module, "_BACKENDS", dict(ocr_module._BACKENDS))
 
     class DummyBackend:
@@ -45,7 +59,11 @@ def test_configured_ocr_backend(monkeypatch):
 
 def test_watcher_is_new_question(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "x")
-    monkeypatch.setattr(watcher_module, "_mss", lambda: type("S", (), {"mss": lambda self=None: DummyMSS()})())
+    monkeypatch.setattr(
+        watcher_module,
+        "_mss",
+        lambda: type("S", (), {"mss": lambda self=None: DummyMSS()})(),
+    )
     cfg = Settings()
     w = Watcher(Region(0, 0, 1, 1), Queue(), cfg)
     assert w.is_new_question("Q1") is True
@@ -54,7 +72,11 @@ def test_watcher_is_new_question(monkeypatch):
 
 def test_watcher_emits_event(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "x")
-    monkeypatch.setattr(watcher_module, "_mss", lambda: type("S", (), {"mss": lambda self=None: DummyMSS()})())
+    monkeypatch.setattr(
+        watcher_module,
+        "_mss",
+        lambda: type("S", (), {"mss": lambda self=None: DummyMSS()})(),
+    )
     cfg = Settings()
     q: Queue = Queue()
     w = Watcher(Region(0, 0, 1, 1), q, cfg, ocr=lambda img: "text")
@@ -73,7 +95,11 @@ def test_watcher_emits_event(monkeypatch):
 
 def test_watcher_pause_resume(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "x")
-    monkeypatch.setattr(watcher_module, "_mss", lambda: type("S", (), {"mss": lambda self=None: DummyMSS()})())
+    monkeypatch.setattr(
+        watcher_module,
+        "_mss",
+        lambda: type("S", (), {"mss": lambda self=None: DummyMSS()})(),
+    )
     cfg = Settings()
     q: Queue = Queue()
     w = Watcher(Region(0, 0, 1, 1), q, cfg, ocr=lambda img: "text")


### PR DESCRIPTION
## Summary
- validate screen region before starting Watcher
- add test ensuring invalid regions raise ValueError

## Testing
- `pre-commit run --files quiz_automation/watcher.py tests/test_watcher.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a377e7e2e88328a2b6d04c89784bfd