### PR TITLE
Add max question limit to quiz runner

### DIFF
--- a/run.py
+++ b/run.py
@@ -90,6 +90,7 @@ def main(argv: list[str] | None = None) -> None:
             gui=gui,
             model_client=model_client,
             stats=stats,
+            max_questions=args.max_questions,
             session_log=log_file,
         )
         runner.start()
@@ -102,11 +103,6 @@ def main(argv: list[str] | None = None) -> None:
                 while True:
                     runner.join(timeout=1)
                     if not runner.is_alive():
-                        break
-                    if (
-                        args.max_questions
-                        and stats.questions_answered >= args.max_questions
-                    ):
                         break
         except KeyboardInterrupt:
             pass
@@ -138,6 +134,7 @@ def main(argv: list[str] | None = None) -> None:
 
             model_client=model_client,
             stats=stats,
+            max_questions=args.max_questions,
             session_log=log_file,
         )
         runner.start()
@@ -145,11 +142,6 @@ def main(argv: list[str] | None = None) -> None:
             while True:
                 runner.join(timeout=1)
                 if not runner.is_alive():
-                    break
-                if (
-                    args.max_questions
-                    and stats.questions_answered >= args.max_questions
-                ):
                     break
         except KeyboardInterrupt:
             pass

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -77,6 +77,78 @@ def test_cli_uses_selected_backend_and_stops(backend: str, client_attr: str) -> 
 
     assert instantiated.get("created", False)
     assert Runner.return_value.stop.call_count == 1
+    assert Runner.call_args.kwargs["max_questions"] == 0
+
+
+@pytest.mark.parametrize(
+    "backend, client_attr",
+    [
+        ("chatgpt", "ChatGPTClient"),
+        ("local", "LocalModelClient"),
+    ],
+)
+def test_cli_gui_mode_passes_gui_and_stops(backend: str, client_attr: str) -> None:
+    """Ensure GUI mode constructs the runner with a GUI instance and stops."""
+
+    import importlib
+    import sys
+
+    sys.modules.setdefault(
+        "pydantic",
+        SimpleNamespace(
+            BaseModel=object,
+            ValidationError=Exception,
+            field_validator=lambda *a, **k: (lambda f: f),
+        ),
+    )
+    sys.modules.setdefault(
+        "pydantic_settings",
+        SimpleNamespace(BaseSettings=object, SettingsConfigDict=dict),
+    )
+
+    run = importlib.import_module("run")
+    from quiz_automation.types import Point, Region
+
+    _cfg = SimpleNamespace(
+        quiz_region=Region(1, 2, 3, 4),
+        chat_box=Point(5, 6),
+        response_region=Region(7, 8, 9, 10),
+        option_base=Point(11, 12),
+    )
+    stats = SimpleNamespace(questions_answered=0)
+    instantiated = {}
+
+    class DummyClient:
+        def __init__(self, *a, **k):
+            instantiated["created"] = True
+
+    class DummyGUI:
+        def __init__(self):
+            self._app = None
+
+    with patch.object(run, "Settings", return_value=_cfg), patch.object(
+        run, "Stats", return_value=stats
+    ), patch.object(run, "QuizRunner") as Runner, patch.object(
+        run, client_attr, DummyClient
+    ), patch.object(run, "QuizGUI", DummyGUI):
+        Runner.return_value.is_alive.side_effect = [True, False]
+        Runner.return_value.start.return_value = None
+        Runner.return_value.join.return_value = None
+        Runner.return_value.stop.return_value = None
+
+        run.main([
+            "--mode",
+            "gui",
+            "--backend",
+            backend,
+            "--max-questions",
+            "0",
+        ])
+
+    assert instantiated.get("created", False)
+    assert Runner.return_value.stop.call_count == 1
+    assert Runner.call_args.kwargs["gui"] is not None
+    assert Runner.call_args.kwargs["max_questions"] == 0
 def test_cli_temperature(monkeypatch) -> None:
     import importlib
     import sys


### PR DESCRIPTION
## Summary
- allow `QuizRunner` to stop after an optional max question count
- wire CLI `--max-questions` flag through to the runner in both GUI and headless modes
- extend tests to cover the GUI path and exercise the new limit

## Testing
- `pytest tests/test_runner.py tests/test_run.py`
- `pre-commit run --files quiz_automation/runner.py run.py tests/test_run.py tests/test_runner.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ae50ce98832885e2f837cd86f17f