### PR TITLE
Sync CLI configuration with global settings

### DIFF
--- a/run.py
+++ b/run.py
@@ -75,7 +75,13 @@ def main(argv: list[str] | None = None) -> None:
         cfg = Settings(_env_file=args.config) if args.config else Settings()
         if args.temperature is not None:
             cfg.temperature = args.temperature
-            global_settings.temperature = args.temperature
+        for attr in (
+            "openai_model",
+            "openai_system_prompt",
+            "ocr_backend",
+            "temperature",
+        ):
+            setattr(global_settings, attr, getattr(cfg, attr))
         options = list("ABCD")
         stats = Stats()
         model_client = (
@@ -120,9 +126,13 @@ def main(argv: list[str] | None = None) -> None:
         if args.temperature is not None:
             cfg_kwargs["temperature"] = args.temperature
         cfg = Settings(**cfg_kwargs)
-        if args.temperature is not None:
-            cfg.temperature = args.temperature
-            global_settings.temperature = args.temperature
+        for attr in (
+            "openai_model",
+            "openai_system_prompt",
+            "ocr_backend",
+            "temperature",
+        ):
+            setattr(global_settings, attr, getattr(cfg, attr))
         options = list("ABCD")
         stats = Stats()
         model_client = (

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -48,6 +48,10 @@ def test_cli_uses_selected_backend_and_stops(backend: str, client_attr: str) -> 
         chat_box=Point(5, 6),
         response_region=Region(7, 8, 9, 10),
         option_base=Point(11, 12),
+        openai_model="dummy-model",
+        openai_system_prompt="dummy-prompt",
+        ocr_backend="dummy-ocr",
+        temperature=0.0,
     )
     stats = SimpleNamespace(questions_answered=0)
     instantiated = {}
@@ -55,6 +59,8 @@ def test_cli_uses_selected_backend_and_stops(backend: str, client_attr: str) -> 
     class DummyClient:
         def __init__(self, *a, **k):
             instantiated["created"] = True
+
+    from quiz_automation.config import settings as global_settings
 
     with patch.object(run, "Settings", return_value=_cfg), patch.object(
         run, "Stats", return_value=stats
@@ -77,6 +83,10 @@ def test_cli_uses_selected_backend_and_stops(backend: str, client_attr: str) -> 
 
     assert instantiated.get("created", False)
     assert Runner.return_value.stop.call_count == 1
+    global_settings.openai_model = "o4-mini-high"
+    global_settings.openai_system_prompt = "Reply with JSON {'answer':'A|B|C|D'}"
+    global_settings.ocr_backend = None
+    global_settings.temperature = 0.0
 def test_cli_temperature(monkeypatch) -> None:
     import importlib
     import sys
@@ -103,6 +113,9 @@ def test_cli_temperature(monkeypatch) -> None:
         chat_box=Point(5, 6),
         response_region=Region(7, 8, 9, 10),
         option_base=Point(11, 12),
+        openai_model="dummy-model",
+        openai_system_prompt="dummy-prompt",
+        ocr_backend="dummy-ocr",
         temperature=0.0,
     )
     stats = SimpleNamespace(questions_answered=0)
@@ -112,7 +125,11 @@ def test_cli_temperature(monkeypatch) -> None:
         def __init__(self, *a, **k):
             captured.temp = global_settings.temperature
 
-    with patch.object(run, "Settings", return_value=cfg), patch.object(
+    def fake_settings(**kwargs):
+        cfg.temperature = kwargs.get("temperature", cfg.temperature)
+        return cfg
+
+    with patch.object(run, "Settings", side_effect=fake_settings), patch.object(
         run, "Stats", return_value=stats
     ), patch.object(run, "QuizRunner") as Runner, patch.object(
         run, "ChatGPTClient", DummyClient
@@ -137,4 +154,73 @@ def test_cli_temperature(monkeypatch) -> None:
 
     assert captured.temp == 0.7
     assert cfg.temperature == 0.7
+    global_settings.openai_model = "o4-mini-high"
+    global_settings.openai_system_prompt = "Reply with JSON {'answer':'A|B|C|D'}"
+    global_settings.ocr_backend = None
+    global_settings.temperature = 0.0
+
+
+def test_cli_propagates_settings_to_global() -> None:
+    import importlib
+    import sys
+
+    sys.modules.setdefault(
+        "pydantic",
+        SimpleNamespace(
+            BaseModel=object,
+            ValidationError=Exception,
+            field_validator=lambda *a, **k: (lambda f: f),
+        ),
+    )
+    sys.modules.setdefault(
+        "pydantic_settings",
+        SimpleNamespace(BaseSettings=object, SettingsConfigDict=dict),
+    )
+
+    run = importlib.import_module("run")
+    from quiz_automation.config import settings as global_settings
+    from quiz_automation.types import Point, Region
+
+    cfg = SimpleNamespace(
+        quiz_region=Region(1, 2, 3, 4),
+        chat_box=Point(5, 6),
+        response_region=Region(7, 8, 9, 10),
+        option_base=Point(11, 12),
+        openai_model="model-x",
+        openai_system_prompt="prompt-y",
+        ocr_backend="ocr-z",
+        temperature=0.2,
+    )
+    stats = SimpleNamespace(questions_answered=0)
+
+    class DummyClient:
+        def __init__(self, *a, **k):
+            pass
+
+    with patch.object(run, "Settings", return_value=cfg), patch.object(
+        run, "Stats", return_value=stats
+    ), patch.object(run, "QuizRunner") as Runner, patch.object(
+        run, "ChatGPTClient", DummyClient
+    ):
+        Runner.return_value.is_alive.side_effect = [True, False]
+        Runner.return_value.start.return_value = None
+        Runner.return_value.join.return_value = None
+        Runner.return_value.stop.return_value = None
+
+        run.main([
+            "--mode",
+            "headless",
+            "--backend",
+            "chatgpt",
+            "--max-questions",
+            "0",
+        ])
+
+    assert global_settings.openai_model == "model-x"
+    assert global_settings.openai_system_prompt == "prompt-y"
+    assert global_settings.ocr_backend == "ocr-z"
+    assert global_settings.temperature == 0.2
+    global_settings.openai_model = "o4-mini-high"
+    global_settings.openai_system_prompt = "Reply with JSON {'answer':'A|B|C|D'}"
+    global_settings.ocr_backend = None
     global_settings.temperature = 0.0


### PR DESCRIPTION
## Summary
- propagate key config fields (model, system prompt, OCR backend, temp) from CLI settings to global settings
- add tests ensuring CLI overrides update global settings

## Testing
- `pytest tests/test_run.py`

------
https://chatgpt.com/codex/tasks/task_e_68a3ae5017c083289182a34aff5258bf