### PR TITLE
Build dict for mss grab

### DIFF
--- a/quiz_automation/watcher.py
+++ b/quiz_automation/watcher.py
@@ -55,7 +55,13 @@ class Watcher(threading.Thread):
         except Exception as exc:
             logger.exception("Failed to obtain mss instance")
             raise RuntimeError("Screen capture requires the 'mss' package") from exc
-        return mss_module.mss().grab(self.region.as_tuple())
+        bbox = {
+            "left": self.region.left,
+            "top": self.region.top,
+            "width": self.region.width,
+            "height": self.region.height,
+        }
+        return mss_module.mss().grab(bbox)
 
     def ocr(self, img) -> str:  # pragma: no cover - behaviour provided by backend
         """Return OCR text for *img* using the configured backend."""


### PR DESCRIPTION
## Summary
- Pass region dict to `mss` when capturing screen
- Ensure capture tests verify dict is used

## Testing
- `pre-commit run --files quiz_automation/watcher.py tests/test_watcher.py`
- `pytest tests/test_watcher.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3ae4e7b388328bf78649a900dfa7e