### PR TITLE
Validate and convert watcher regions

### DIFF
--- a/quiz_automation/watcher.py
+++ b/quiz_automation/watcher.py
@@ -9,8 +9,7 @@ from queue import Queue
 
 from .config import Settings
 from .ocr import OCRBackend, get_backend
-from .types import Region
-from .utils import hash_text, validate_region
+from .utils import Region, hash_text, validate_region
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +30,7 @@ class Watcher(threading.Thread):
 
     def __init__(
         self,
-        region: Region,
+        region: Region | tuple[int, int, int, int],
         queue: Queue,
         cfg: Settings,
         ocr: OCRBackend | None = None,
@@ -39,6 +38,8 @@ class Watcher(threading.Thread):
         """Initialize the watcher thread."""
         super().__init__(daemon=True)
         validate_region(region)
+        if not isinstance(region, Region):
+            region = Region(*region)
         self.region = region
         self.queue = queue
         self.cfg = cfg

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -38,6 +38,15 @@ def test_invalid_region_raises_value_error(monkeypatch):
         Watcher(Region(0, 0, 0, 1), Queue(), cfg)
 
 
+def test_tuple_region_validated_and_converted(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    cfg = Settings()
+    with pytest.raises(ValueError):
+        Watcher((0, 0, 0, 1), Queue(), cfg)
+    w = Watcher((0, 0, 1, 1), Queue(), cfg)
+    assert isinstance(w.region, Region)
+
+
 def test_configured_ocr_backend(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "x")
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- Import `Region` from `quiz_automation.utils`
- Validate and convert region tuples in `Watcher`
- Test tuple region validation and conversion

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3ae4f5ce48328bb9c2b433490ce72