### PR TITLE
Add Docker Compose setup and CI for API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,4 +41,12 @@ jobs:
           pip install -e .
           pip install pytest pytest-cov
       - name: Run tests
+        run: pytest
 
+  docker-build:
+    name: Docker Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build API image
+        run: docker build -f server/Dockerfile .

--- a/README.md
+++ b/README.md
@@ -147,14 +147,23 @@ pip install -e .[full]
 
 ## Docker
 
-Build the image:
+The repository provides a `server/Dockerfile` for running the FastAPI service.
+
+Build the image with Docker Compose:
 
 ```bash
-docker build -t basic-ai-auto-assistant .
+docker compose build
 ```
 
-Run the container:
+Start the API along with a RabbitMQ broker and PostgreSQL database:
 
 ```bash
-docker run --rm basic-ai-auto-assistant
+docker compose up
+```
+
+The API will be available at `http://localhost:8000/health`. To build the image
+manually without Compose use:
+
+```bash
+docker build -f server/Dockerfile -t basic-ai-auto-assistant-api .
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: "3.9"
+services:
+  api:
+    build:
+      context: .
+      dockerfile: server/Dockerfile
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db
+      - broker
+  broker:
+    image: rabbitmq:3-management
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: app
+    ports:
+      - "5432:5432"

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY . /app
+
+RUN pip install --no-cache-dir -e .[full] fastapi uvicorn[standard]
+
+CMD ["uvicorn", "server.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/server/main.py
+++ b/server/main.py
@@ -1,0 +1,9 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    """Simple health check endpoint."""
+    return {"status": "ok"}

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -72,14 +72,16 @@ def test_cli_uses_selected_backend_and_stops(backend: str, client_attr: str) -> 
         Runner.return_value.join.return_value = None
         Runner.return_value.stop.return_value = None
 
-        run.main([
-            "--mode",
-            "headless",
-            "--backend",
-            backend,
-            "--max-questions",
-            "0",
-        ])
+        run.main(
+            [
+                "--mode",
+                "headless",
+                "--backend",
+                backend,
+                "--max-questions",
+                "0",
+            ]
+        )
 
     assert instantiated.get("created", False)
     assert Runner.return_value.stop.call_count == 1
@@ -87,7 +89,6 @@ def test_cli_uses_selected_backend_and_stops(backend: str, client_attr: str) -> 
     global_settings.openai_system_prompt = "Reply with JSON {'answer':'A|B|C|D'}"
     global_settings.ocr_backend = None
     global_settings.temperature = 0.0
-=======
     assert Runner.call_args.kwargs["max_questions"] == 0
 
 
@@ -125,6 +126,10 @@ def test_cli_gui_mode_passes_gui_and_stops(backend: str, client_attr: str) -> No
         chat_box=Point(5, 6),
         response_region=Region(7, 8, 9, 10),
         option_base=Point(11, 12),
+        openai_model="dummy-model",
+        openai_system_prompt="dummy-prompt",
+        ocr_backend="dummy-ocr",
+        temperature=0.0,
     )
     stats = SimpleNamespace(questions_answered=0)
     instantiated = {}
@@ -141,25 +146,31 @@ def test_cli_gui_mode_passes_gui_and_stops(backend: str, client_attr: str) -> No
         run, "Stats", return_value=stats
     ), patch.object(run, "QuizRunner") as Runner, patch.object(
         run, client_attr, DummyClient
-    ), patch.object(run, "QuizGUI", DummyGUI):
+    ), patch.object(
+        run, "QuizGUI", DummyGUI
+    ):
         Runner.return_value.is_alive.side_effect = [True, False]
         Runner.return_value.start.return_value = None
         Runner.return_value.join.return_value = None
         Runner.return_value.stop.return_value = None
 
-        run.main([
-            "--mode",
-            "gui",
-            "--backend",
-            backend,
-            "--max-questions",
-            "0",
-        ])
+        run.main(
+            [
+                "--mode",
+                "gui",
+                "--backend",
+                backend,
+                "--max-questions",
+                "0",
+            ]
+        )
 
     assert instantiated.get("created", False)
     assert Runner.return_value.stop.call_count == 1
     assert Runner.call_args.kwargs["gui"] is not None
     assert Runner.call_args.kwargs["max_questions"] == 0
+
+
 def test_cli_temperature(monkeypatch) -> None:
     import importlib
     import sys
@@ -280,14 +291,16 @@ def test_cli_propagates_settings_to_global() -> None:
         Runner.return_value.join.return_value = None
         Runner.return_value.stop.return_value = None
 
-        run.main([
-            "--mode",
-            "headless",
-            "--backend",
-            "chatgpt",
-            "--max-questions",
-            "0",
-        ])
+        run.main(
+            [
+                "--mode",
+                "headless",
+                "--backend",
+                "chatgpt",
+                "--max-questions",
+                "0",
+            ]
+        )
 
     assert global_settings.openai_model == "model-x"
     assert global_settings.openai_system_prompt == "prompt-y"


### PR DESCRIPTION
## Summary
- add FastAPI server image installing project with full extras
- orchestrate API, RabbitMQ, and Postgres via docker-compose
- document container workflow and add CI checks
- fix test file to remove merge artifact and missing fields

## Testing
- `pre-commit run --files README.md docker-compose.yml server/Dockerfile server/main.py .github/workflows/ci.yml tests/test_run.py`
- `pytest`
- `docker build -f server/Dockerfile .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c0f8dfd48328b2a6dd718d6c3d5c