### PR TITLE
Add Celery-backed async answer endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,8 @@ QUIZ_REGION=[100,100,600,400]
 CHAT_BOX=[800,900]
 RESPONSE_REGION=[100,550,600,150]
 OPTION_BASE=[100,520]
+CELERY_BROKER_URL=redis://localhost:6379/0
+CELERY_RESULT_BACKEND=redis://localhost:6379/0
+# Example RabbitMQ configuration:
+# CELERY_BROKER_URL=amqp://guest:guest@localhost//
+# CELERY_RESULT_BACKEND=rpc://

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,10 @@ dependencies = [
     "pydantic",
     "pydantic-settings",
     "mss",
+    "fastapi",
+    "celery",
+    "httpx",
+    "redis",
 ]
 
 [project.optional-dependencies]

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,0 +1,1 @@
+"""Server package exposing FastAPI application and Celery tasks."""

--- a/server/app.py
+++ b/server/app.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import base64
+import os
+from io import BytesIO
+from typing import List, Optional
+
+from celery import Celery
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from quiz_automation.model_client import LocalModelClient
+from quiz_automation.ocr import get_backend
+
+# Celery configuration -----------------------------------------------------
+
+CELERY_BROKER_URL = os.getenv("CELERY_BROKER_URL", "redis://localhost:6379/0")
+CELERY_RESULT_BACKEND = os.getenv("CELERY_RESULT_BACKEND", CELERY_BROKER_URL)
+
+celery_app = Celery(
+    "quiz_tasks", broker=CELERY_BROKER_URL, backend=CELERY_RESULT_BACKEND
+)
+
+# FastAPI application ------------------------------------------------------
+
+app = FastAPI()
+
+
+class AnswerRequest(BaseModel):
+    """Payload for the answer endpoint."""
+
+    question: Optional[str] = None
+    image: Optional[str] = None  # Base64 encoded image
+    options: List[str]
+
+
+@celery_app.task
+def process_answer(
+    question: str | None, image_b64: str | None, options: List[str]
+) -> str:
+    """Run OCR and model prediction for *question* or *image*."""
+
+    question_text = question or ""
+    if image_b64 and not question:
+        try:
+            from PIL import Image  # type: ignore
+        except Exception as exc:  # pragma: no cover - optional dependency
+            raise RuntimeError("Pillow not available") from exc
+        img_bytes = base64.b64decode(image_b64)
+        with Image.open(BytesIO(img_bytes)) as img:
+            ocr_backend = get_backend()
+            question_text = ocr_backend(img)
+
+    client = LocalModelClient()
+    return client.ask(question_text, options)
+
+
+@app.post("/answer")
+def create_answer(request: AnswerRequest) -> dict[str, str]:
+    """Enqueue an OCR/model job and return the task id."""
+
+    task = process_answer.delay(request.question, request.image, request.options)
+    return {"task_id": task.id}
+
+
+@app.get("/answer/{task_id}")
+def get_answer(task_id: str) -> dict[str, str]:
+    """Return task status and result when available."""
+
+    result = celery_app.AsyncResult(task_id)
+    if result.successful():
+        return {"status": "completed", "answer": result.result}
+    if result.failed():  # pragma: no cover - exercised via tests
+        raise HTTPException(status_code=500, detail=str(result.result))
+    return {"status": "pending"}

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -72,14 +72,16 @@ def test_cli_uses_selected_backend_and_stops(backend: str, client_attr: str) -> 
         Runner.return_value.join.return_value = None
         Runner.return_value.stop.return_value = None
 
-        run.main([
-            "--mode",
-            "headless",
-            "--backend",
-            backend,
-            "--max-questions",
-            "0",
-        ])
+        run.main(
+            [
+                "--mode",
+                "headless",
+                "--backend",
+                backend,
+                "--max-questions",
+                "0",
+            ]
+        )
 
     assert instantiated.get("created", False)
     assert Runner.return_value.stop.call_count == 1
@@ -87,7 +89,6 @@ def test_cli_uses_selected_backend_and_stops(backend: str, client_attr: str) -> 
     global_settings.openai_system_prompt = "Reply with JSON {'answer':'A|B|C|D'}"
     global_settings.ocr_backend = None
     global_settings.temperature = 0.0
-=======
     assert Runner.call_args.kwargs["max_questions"] == 0
 
 
@@ -125,6 +126,10 @@ def test_cli_gui_mode_passes_gui_and_stops(backend: str, client_attr: str) -> No
         chat_box=Point(5, 6),
         response_region=Region(7, 8, 9, 10),
         option_base=Point(11, 12),
+        openai_model="dummy-model",
+        openai_system_prompt="dummy-prompt",
+        ocr_backend="dummy-ocr",
+        temperature=0.0,
     )
     stats = SimpleNamespace(questions_answered=0)
     instantiated = {}
@@ -141,25 +146,31 @@ def test_cli_gui_mode_passes_gui_and_stops(backend: str, client_attr: str) -> No
         run, "Stats", return_value=stats
     ), patch.object(run, "QuizRunner") as Runner, patch.object(
         run, client_attr, DummyClient
-    ), patch.object(run, "QuizGUI", DummyGUI):
+    ), patch.object(
+        run, "QuizGUI", DummyGUI
+    ):
         Runner.return_value.is_alive.side_effect = [True, False]
         Runner.return_value.start.return_value = None
         Runner.return_value.join.return_value = None
         Runner.return_value.stop.return_value = None
 
-        run.main([
-            "--mode",
-            "gui",
-            "--backend",
-            backend,
-            "--max-questions",
-            "0",
-        ])
+        run.main(
+            [
+                "--mode",
+                "gui",
+                "--backend",
+                backend,
+                "--max-questions",
+                "0",
+            ]
+        )
 
     assert instantiated.get("created", False)
     assert Runner.return_value.stop.call_count == 1
     assert Runner.call_args.kwargs["gui"] is not None
     assert Runner.call_args.kwargs["max_questions"] == 0
+
+
 def test_cli_temperature(monkeypatch) -> None:
     import importlib
     import sys
@@ -280,14 +291,16 @@ def test_cli_propagates_settings_to_global() -> None:
         Runner.return_value.join.return_value = None
         Runner.return_value.stop.return_value = None
 
-        run.main([
-            "--mode",
-            "headless",
-            "--backend",
-            "chatgpt",
-            "--max-questions",
-            "0",
-        ])
+        run.main(
+            [
+                "--mode",
+                "headless",
+                "--backend",
+                "chatgpt",
+                "--max-questions",
+                "0",
+            ]
+        )
 
     assert global_settings.openai_model == "model-x"
     assert global_settings.openai_system_prompt == "prompt-y"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from server.app import app, celery_app
+
+
+def test_answer_endpoint_eager(monkeypatch) -> None:
+    """POST /answer triggers Celery task and returns model response."""
+
+    celery_app.conf.task_always_eager = True
+    celery_app.conf.task_store_eager_result = True
+    celery_app.conf.broker_url = "memory://"
+    celery_app.conf.result_backend = "cache+memory://"
+    client = TestClient(app)
+
+    payload = {
+        "question": "What color is the clear sky?",
+        "options": ["Blue", "Red", "Green", "Yellow"],
+    }
+    resp = client.post("/answer", json=payload)
+    assert resp.status_code == 200
+    task_id = resp.json()["task_id"]
+
+    res = client.get(f"/answer/{task_id}")
+    assert res.status_code == 200
+    data = res.json()
+    assert data["status"] == "completed"
+    assert data["answer"] == "A"


### PR DESCRIPTION
## Summary
- configure Celery and FastAPI server with async `/answer` endpoint
- move OCR and model prediction into Celery task
- document broker URLs in `.env.example`
- add integration test running Celery in eager mode

## Testing
- `pre-commit run --files server/app.py server/__init__.py .env.example pyproject.toml tests/test_server.py tests/test_run.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4c0f9b07483289f054a6369a3b40d